### PR TITLE
[AMSDK-8378] - Places Stop API with boolean to clear places data

### DIFF
--- a/code/places-monitor-android/build.gradle
+++ b/code/places-monitor-android/build.gradle
@@ -69,7 +69,7 @@ android {
 dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.adobe.marketing.mobile:sdk-core:1.2.2'
-    implementation 'com.adobe.marketing.mobile:places:1.2.0'
+    implementation 'com.adobe.marketing.mobile:places:1.3.0'
     implementation 'com.google.android.gms:play-services-location:16.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:${rootProject.ext.mockitoCoreVersion}"

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -201,7 +201,7 @@ public class PlacesActivity extends Activity {
 	 * Permission handler method called when user has denied permission to access fine location.
 	 */
 	private void onPermissionDenied() {
-		PlacesMonitor.stop(false);
+		PlacesMonitor.stop(true);
 		finish();
 	}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -201,7 +201,7 @@ public class PlacesActivity extends Activity {
 	 * Permission handler method called when user has denied permission to access fine location.
 	 */
 	private void onPermissionDenied() {
-		PlacesMonitor.stop();
+		PlacesMonitor.stop(false);
 		finish();
 	}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
@@ -154,6 +154,11 @@ class PlacesGeofenceManager {
 
 	/**
 	 * Stops monitoring for entry and exit event on nearby places of interest.
+     *
+     * Calling this method with YES for clearData will purge the {@link #userWithinGeofences} data in addition to stop monitoring
+     * for further geofence events.
+     *
+     * @param clearData a boolean indicating whether to clear the {@link #userWithinGeofences} from in-memory and persistence
 	 */
 	void stopMonitoringFences(final boolean clearData) {
 		AdobeCallback<Void> onSuccess = new AdobeCallback<Void>() {

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
@@ -155,7 +155,7 @@ class PlacesGeofenceManager {
 	/**
 	 * Stops monitoring for entry and exit event on nearby places of interest.
 	 */
-	void stopMonitoringFences() {
+	void stopMonitoringFences(final boolean clearData) {
 		AdobeCallback<Void> onSuccess = new AdobeCallback<Void>() {
 			@Override
 			public void call(Void aVoid) {
@@ -169,6 +169,11 @@ class PlacesGeofenceManager {
 				Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to stop monitoring all the fences," + message);
 			}
 		};
+
+		if(clearData){
+			userWithinGeofences.clear();
+			saveUserWithinGeofences();
+		}
 
 		unregisterPOIS(onSuccess, onFailiure);
 	}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
@@ -23,7 +23,6 @@ final class PlacesMonitorConstants {
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
 	static final String EXTENSION_VERSION = "1.0.2";
-	static final String CONTINUOUS_MONITORING = "continuousmonitoring";
 
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";
@@ -44,32 +43,16 @@ final class PlacesMonitorConstants {
 	}
 
 	static final class EventSource {
-		static final String RESPONSE_CONTENT 	= "com.adobe.eventsource.responsecontent";
 		static final String REQUEST_CONTENT = "com.adobe.eventsource.requestcontent";
 		static final String SHARED_STATE = "com.adobe.eventsource.sharedstate";
+
 
 		private EventSource() {
 		}
 	}
 
 	static final class EventDataKeys {
-
-		static final String NEAR_BY_PLACES_LIST = "nearbyplaceslist";
-		static final String REQUEST_TYPE = "requesttype";
-		static final String REQUEST_TYPE_GET_NEARBY_PLACES = "requestgetnearbyplaces";
-		static final String REQUEST_TYPE_PROCESS_REGION_EVENT = "requestprocessregionevent";
-
-		static final String PLACES_COUNT = "count";
-		static final String LATITUDE = "latitude";
-		static final String LONGITUDE = "longitude";
-
-		static final String GEOFENCE_TYPE_NONE  = "none";
-		static final String GEOFENCE_TYPE_ENTRY = "entry";
-		static final String GEOFENCE_TYPE_EXIT  = "exit";
-
-		static final String REGION_ID = "regionid";
-		static final String REGION_EVENT_TYPE = "regioneventtype";
-
+		static final String EVENT_DATA_CLEAR	= "clearclientdata";
 		private EventDataKeys() {
 		}
 	}
@@ -78,7 +61,6 @@ final class PlacesMonitorConstants {
 	static final class EventType {
 		static final String HUB = "com.adobe.eventtype.hub";
 		static final String MONITOR = "com.adobe.eventtype.placesmonitor";
-		static final String PLACES = "com.adobe.eventtype.places";
 
 		private EventType() {
 		}
@@ -87,8 +69,6 @@ final class PlacesMonitorConstants {
 	static final class SharedState {
 		static final String STATEOWNER = "stateowner";
 		static final String CONFIGURATION = "com.adobe.module.configuration";
-		static final String PLACES = "com.adobe.module.places";
-
 		private SharedState() {
 		}
 	}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -262,7 +262,15 @@ class PlacesMonitorInternal extends Extension {
 		if (PlacesMonitorConstants.EVENTNAME_START.equals(eventName)) {
 			startMonitoring();
 		} else if (PlacesMonitorConstants.EVENTNAME_STOP.equals(eventName)) {
-			stopMonitoring();
+
+			EventData data = event.getData();
+			if(data != null && !data.isEmpty()){
+				boolean shouldClear = data.optBoolean(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_CLEAR, false);
+				stopMonitoring(shouldClear);
+				return;
+			}
+
+			stopMonitoring(false);
 		} else if (PlacesMonitorConstants.EVENTNAME_UPDATE.equals(eventName)) {
 			updateLocation();
 		} else {
@@ -292,10 +300,17 @@ class PlacesMonitorInternal extends Extension {
 	 * This method requests the {@link #locationManager} to stop monitoring the device current location.
 	 * It also requests the {@link #geofenceManager} to stop monitoring the fences that are currently being monitored.
 	 *
+	 * Calling this method with YES for clearData will purge the data even if the monitor is not actively tracking
+	 * the device's location.
+	 *
+	 * @param clearData pass YES to clear all client-side Places data from the device.
 	 */
-	private void stopMonitoring() {
+	private void stopMonitoring(final boolean clearData) {
 		locationManager.stopMonitoring();
 		geofenceManager.stopMonitoringFences();
+		if(clearData){
+			Places.clear();
+		}
 	}
 
 	/**

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -307,7 +307,7 @@ class PlacesMonitorInternal extends Extension {
 	 */
 	private void stopMonitoring(final boolean clearData) {
 		locationManager.stopMonitoring();
-		geofenceManager.stopMonitoringFences();
+		geofenceManager.stopMonitoringFences(clearData);
 		if(clearData){
 			Places.clear();
 		}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -263,14 +263,13 @@ class PlacesMonitorInternal extends Extension {
 			startMonitoring();
 		} else if (PlacesMonitorConstants.EVENTNAME_STOP.equals(eventName)) {
 
+			boolean shouldClear = false;
 			EventData data = event.getData();
 			if(data != null && !data.isEmpty()){
-				boolean shouldClear = data.optBoolean(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_CLEAR, false);
-				stopMonitoring(shouldClear);
-				return;
+				shouldClear = data.optBoolean(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_CLEAR, false);
 			}
 
-			stopMonitoring(false);
+			stopMonitoring(shouldClear);
 		} else if (PlacesMonitorConstants.EVENTNAME_UPDATE.equals(eventName)) {
 			updateLocation();
 		} else {

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
@@ -339,7 +339,7 @@ public class PlacesActivityTests {
 
 		// verify stop monitoring is called
 		verifyStatic(PlacesMonitor.class, Mockito.times(1));
-		PlacesMonitor.stop(false);
+		PlacesMonitor.stop(true);
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();
@@ -353,7 +353,7 @@ public class PlacesActivityTests {
 
 		// verify stop monitoring is not called
 		verifyStatic(PlacesMonitor.class, Mockito.times(0));
-		PlacesMonitor.stop(false);
+		PlacesMonitor.stop(true);
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();
@@ -365,7 +365,7 @@ public class PlacesActivityTests {
 		verifyStatic(PlacesMonitor.class, Mockito.times(0));
 		PlacesMonitor.start();
 		verifyStatic(PlacesMonitor.class, Mockito.times(0));
-		PlacesMonitor.stop(false);
+		PlacesMonitor.stop(true);
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
@@ -339,7 +339,7 @@ public class PlacesActivityTests {
 
 		// verify stop monitoring is called
 		verifyStatic(PlacesMonitor.class, Mockito.times(1));
-		PlacesMonitor.stop();
+		PlacesMonitor.stop(false);
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();
@@ -353,7 +353,7 @@ public class PlacesActivityTests {
 
 		// verify stop monitoring is not called
 		verifyStatic(PlacesMonitor.class, Mockito.times(0));
-		PlacesMonitor.stop();
+		PlacesMonitor.stop(false);
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();
@@ -365,7 +365,7 @@ public class PlacesActivityTests {
 		verifyStatic(PlacesMonitor.class, Mockito.times(0));
 		PlacesMonitor.start();
 		verifyStatic(PlacesMonitor.class, Mockito.times(0));
-		PlacesMonitor.stop();
+		PlacesMonitor.stop(false);
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorInternalTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorInternalTests.java
@@ -250,7 +250,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(0)).startMonitoring();
 		verify(locationManager, times(0)).stopMonitoring();
 		verify(locationManager, times(0)).updateLocation();
-		verify(geofenceManager, times(0)).stopMonitoringFences();
+		verify(geofenceManager, times(0)).stopMonitoringFences(anyBoolean());
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 	}
 
@@ -273,7 +273,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(1)).startMonitoring();
 		verify(locationManager, times(0)).stopMonitoring();
 		verify(locationManager, times(0)).updateLocation();
-		verify(geofenceManager, times(0)).stopMonitoringFences();
+		verify(geofenceManager, times(0)).stopMonitoringFences(anyBoolean());
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 	}
 
@@ -297,7 +297,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(0)).startMonitoring();
 		verify(locationManager, times(1)).stopMonitoring();
 		verify(locationManager, times(0)).updateLocation();
-		verify(geofenceManager, times(1)).stopMonitoringFences();
+		verify(geofenceManager, times(1)).stopMonitoringFences(true);
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 
 		// verify places call
@@ -325,7 +325,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(0)).startMonitoring();
 		verify(locationManager, times(1)).stopMonitoring();
 		verify(locationManager, times(0)).updateLocation();
-		verify(geofenceManager, times(1)).stopMonitoringFences();
+		verify(geofenceManager, times(1)).stopMonitoringFences(false);
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 
 		// verify places call
@@ -353,7 +353,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(0)).startMonitoring();
 		verify(locationManager, times(1)).stopMonitoring();
 		verify(locationManager, times(0)).updateLocation();
-		verify(geofenceManager, times(1)).stopMonitoringFences();
+		verify(geofenceManager, times(1)).stopMonitoringFences(false);
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 
 		// verify places call
@@ -380,7 +380,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(0)).startMonitoring();
 		verify(locationManager, times(0)).stopMonitoring();
 		verify(locationManager, times(1)).updateLocation();
-		verify(geofenceManager, times(0)).stopMonitoringFences();
+		verify(geofenceManager, times(0)).stopMonitoringFences(anyBoolean());
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 	}
 
@@ -402,7 +402,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(0)).startMonitoring();
 		verify(locationManager, times(0)).stopMonitoring();
 		verify(locationManager, times(0)).updateLocation();
-		verify(geofenceManager, times(0)).stopMonitoringFences();
+		verify(geofenceManager, times(0)).stopMonitoringFences(anyBoolean());
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 	}
 
@@ -426,7 +426,7 @@ public class PlacesMonitorInternalTests {
 		verify(locationManager, times(0)).startMonitoring();
 		verify(locationManager, times(1)).stopMonitoring();
 		verify(locationManager, times(1)).updateLocation();
-		verify(geofenceManager, times(1)).stopMonitoringFences();
+		verify(geofenceManager, times(1)).stopMonitoringFences(false);
 		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
 	}
 

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
@@ -53,6 +53,7 @@ final class PlacesMonitorTestConstants {
 
 	static final class EventDataKeys {
 
+		static final String EVENT_DATA_CLEAR	= "clearclientdata";
 		static final String NEAR_BY_PLACES_LIST = "nearbyplaceslist";
 		static final String REQUEST_TYPE = "requesttype";
 		static final String REQUEST_TYPE_GET_NEARBY_PLACES = "requestgetnearbyplaces";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Modified the stop API to accept a boolean param. If YES is passed, all Places data will be removed from the device.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Location data becomes stale quickly if it is no longer being updated. Stale data can lead to false positives from the Rules Engine and improper triggering of location-related experiences. Providing an option to clear data at the time location monitoring is stopped will prevent false positives due to stale location data.

## How Has This Been Tested?

Unit tests. Manual tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
