### PR TITLE
[AMSDK-8709] - API to setting location permission level 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-29
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
@@ -17,7 +17,7 @@ jobs:
   test:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-29
     environment:
       JVM_OPTS: -Xmx3200m
     steps:
@@ -28,7 +28,7 @@ jobs:
   publish:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-29
     environment:
       JVM_OPTS: -Xmx3200m
     steps:

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -14,12 +14,12 @@ artifactoryPassword=xxx
 moduleProjectName=places-monitor-android
 moduleName=places-monitor
 moduleAARName=places-monitor-android-phone-coreBundle-release.aar
-moduleVersion=2.0.0
+moduleVersion=2.1.0
 
 #bourbon-platform-android-module.gradle
 mavenRepoName=AdobeMobilePlacesMonitorSdk
 mavenRepoDescription=Android Places Monitor Extension for Adobe Mobile Marketing
 mavenUploadDryRunFlag=false
-mavenCoreVersion=1.2.0
+mavenCoreVersion=1.4.4
 mavenPlacesVersion=1.3.0
 mavenGoogleLocationServiceVersion=16.0.0

--- a/code/places-monitor-android/build.gradle
+++ b/code/places-monitor-android/build.gradle
@@ -15,11 +15,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -23,6 +23,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.LocalBroadcastManager;
 import android.view.WindowManager;
 
 import com.google.android.gms.location.LocationSettingsStates;
@@ -32,18 +33,20 @@ import static com.google.android.gms.common.ConnectionResult.RESOLUTION_REQUIRED
 public class PlacesActivity extends Activity {
 
 	private static final String FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
+	private static final String BACKGROUND_LOCATION = Manifest.permission.ACCESS_BACKGROUND_LOCATION;
+	private static final String INTENT_PERMISSION_KEY = "intent permission key";
 
 	/**
-	 * Checks if the permission to access fine location is granted.
+	 * Checks if the permission to access fine location during app in use is granted.
 	 * <ol>
 	 *   <li> Returns true for the devices running on versions below Android M, Since Runtime permission not required.</li>
 	 *   <li> Returns true if the permission for using fine location is already granted. </li>
 	 *   <li> Returns false if the permission for using fine location is not granted or if the app context is null.</li>
 	 * </ol>
 	 *
-	 * @return Returns {@code boolean} representing the permission to monitor fine location
+	 * @return Returns {@code boolean} representing the permission to monitor fine location when app is in use
 	 */
-	public static boolean isFineLocationPermissionGranted() {
+	public static boolean isWhileInUsePermissionGranted() {
 		// for version below API 23, need not check permissions
 		if (!isRuntimePermissionRequired()) {
 			return true;
@@ -62,6 +65,35 @@ public class PlacesActivity extends Activity {
 		return permissionState == PackageManager.PERMISSION_GRANTED;
 	}
 
+	/**
+	 * Checks if the permission to access fine location in background is granted.
+	 * <ol>
+	 *   <li> Returns true for the devices running on versions below Android M, Since Runtime permission not required.</li>
+	 *   <li> Returns true if the permission for using fine location in background is already granted. </li>
+	 *   <li> Returns false if the permission for using fine location in background is not granted or if the app context is null.</li>
+	 * </ol>
+	 *
+	 * @return Returns {@code boolean} representing the permission to monitor fine location in background
+	 */
+	public static boolean isBackgroundPermissionGranted() {
+		// for version below API 23, need not check permissions
+		if (!isRuntimePermissionRequired()) {
+			return true;
+		}
+
+		// get hold of the app context. bail out if null
+		Context context = App.getAppContext();
+
+		if (context == null) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to check location permission, App context is not available");
+			return false;
+		}
+
+		// verify the permission for fine location
+		int permissionState = ActivityCompat.checkSelfPermission(context, BACKGROUND_LOCATION);
+		return permissionState == PackageManager.PERMISSION_GRANTED;
+	}
+
 
 	/**
 	 * Request permission to access fine location from the user.
@@ -71,7 +103,7 @@ public class PlacesActivity extends Activity {
 	 * </ol>
 	 *
 	 */
-	public static void askPermission() {
+	public static void askPermission(PlacesMonitorLocationPermission locationPermission) {
 		// for version below API 23, need not ask permission
 		if (!isRuntimePermissionRequired()) {
 			return;
@@ -88,6 +120,7 @@ public class PlacesActivity extends Activity {
 		// start a new task activity
 		Intent intent = new Intent(context, PlacesActivity.class);
 		intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+		intent.putExtra(INTENT_PERMISSION_KEY, locationPermission);
 		context.startActivity(intent);
 	}
 
@@ -104,19 +137,21 @@ public class PlacesActivity extends Activity {
 		// make the activity not interactable
 		getWindow().addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
 
+		if(getIntent() == null || getIntent().getExtras() == null){
+			Log.debug(PlacesMonitorConstants.LOG_TAG, "Cannot request permission. PlacesActivity Intent is null");
+		}
+		PlacesMonitorLocationPermission locationPermission = (PlacesMonitorLocationPermission) getIntent().getExtras().get(INTENT_PERMISSION_KEY);
 
 		boolean shouldProvideRationale =
 			ActivityCompat.shouldShowRequestPermissionRationale(this,
 					FINE_LOCATION);
 
 		if (shouldProvideRationale) {
-			onShowRationale();
+			onShowRationale(locationPermission);
 		} else {
-			ActivityCompat.requestPermissions(this,
-											  new String[] {FINE_LOCATION},
+			ActivityCompat.requestPermissions(this, getPermissionArray(locationPermission),
 											  PlacesMonitorConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE);
 		}
-
 	}
 
 	/**
@@ -185,6 +220,15 @@ public class PlacesActivity extends Activity {
 		return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M);
 	}
 
+
+	private static String[] getPermissionArray(PlacesMonitorLocationPermission placesMonitorLocationPermission) {
+		String[] permissions = new String[]{FINE_LOCATION};
+		if (PlacesMonitorLocationPermission.ALLOW_ALL_TIME == placesMonitorLocationPermission) {
+			permissions = new String[]{FINE_LOCATION, BACKGROUND_LOCATION};
+		}
+		return permissions;
+	}
+
 	// ========================================================================================
 	// Permission Result Handlers
 	// ========================================================================================
@@ -193,7 +237,10 @@ public class PlacesActivity extends Activity {
 	 * Permission handler method called when user has given permission to access fine location.
 	 */
 	private void onPermissionGranted() {
-		PlacesMonitor.start();
+	    Intent intent = new Intent();
+	    intent.setAction(PlacesMonitorConstants.INTENT_ACTION_PERMISSION_GRANTED);
+		LocalBroadcastManager manager = LocalBroadcastManager.getInstance(getApplicationContext());
+		manager.sendBroadcast(intent);
 		finish();
 	}
 
@@ -201,7 +248,9 @@ public class PlacesActivity extends Activity {
 	 * Permission handler method called when user has denied permission to access fine location.
 	 */
 	private void onPermissionDenied() {
-		PlacesMonitor.stop(true);
+        Intent intent = new Intent(PlacesMonitorConstants.INTENT_ACTION_PERMISSION_DENIED);
+        LocalBroadcastManager manager = LocalBroadcastManager.getInstance(getApplicationContext());
+        manager.sendBroadcast(intent);
 		finish();
 	}
 
@@ -220,11 +269,11 @@ public class PlacesActivity extends Activity {
 	 * This method is called when {@link ActivityCompat#shouldShowRequestPermissionRationale(Activity, String)} returns "true",
 	 * which mean when the application was launched earlier and user had "denied" the permission in last launch WITHOUT checking "never show again".
 	 */
-	private void onShowRationale() {
+	private void onShowRationale(PlacesMonitorLocationPermission locationPermission) {
 		Log.debug(PlacesMonitorConstants.LOG_TAG, "Permission not granted on the first attempt. PlacesMonitor extension " +
 				  "doesn't support showing rationale. Requesting permission again");
 		ActivityCompat.requestPermissions(this,
-										  new String[] {FINE_LOCATION},
+				  						  getPermissionArray(locationPermission),
 										  PlacesMonitorConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE);
 	}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -102,6 +102,7 @@ public class PlacesActivity extends Activity {
 	 *   <li> Does not invoke the permission dialog if the app context is null</li>
 	 * </ol>
 	 *
+	 * @param locationPermission The location permission setting that the user will be prompted for, could be {@link PlacesMonitorLocationPermission#WHILE_USING_APP} or {@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME}
 	 */
 	public static void askPermission(PlacesMonitorLocationPermission locationPermission) {
 		// for version below API 23, need not ask permission

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -37,7 +37,7 @@ public class PlacesActivity extends Activity {
 	private static final String INTENT_PERMISSION_KEY = "intent permission key";
 
 	/**
-	 * Checks if the permission to access fine location during app in use is granted.
+	 * Checks if permission to access fine location while app is in use has been granted.
 	 * <ol>
 	 *   <li> Returns true for the devices running on versions below Android M, Since Runtime permission not required.</li>
 	 *   <li> Returns true if the permission for using fine location is already granted. </li>
@@ -66,7 +66,7 @@ public class PlacesActivity extends Activity {
 	}
 
 	/**
-	 * Checks if the permission to access fine location in background is granted.
+	 * Checks if permission to access fine location while the app is in background has been granted.
 	 * <ol>
 	 *   <li> Returns true for the devices running on versions below Android M, Since Runtime permission not required.</li>
 	 *   <li> Returns true if the permission for using fine location in background is already granted. </li>
@@ -104,7 +104,7 @@ public class PlacesActivity extends Activity {
 	 *
 	 * @param locationPermission The location permission setting that the user will be prompted for, could be {@link PlacesMonitorLocationPermission#WHILE_USING_APP} or {@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME}
 	 */
-	public static void askPermission(PlacesMonitorLocationPermission locationPermission) {
+	public static void askPermission(final PlacesMonitorLocationPermission locationPermission) {
 		// for version below API 23, need not ask permission
 		if (!isRuntimePermissionRequired()) {
 			return;

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -25,8 +25,10 @@ import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.view.WindowManager;
-
 import com.google.android.gms.location.LocationSettingsStates;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.google.android.gms.common.ConnectionResult.RESOLUTION_REQUIRED;
 
@@ -102,7 +104,7 @@ public class PlacesActivity extends Activity {
 	 *   <li> Does not invoke the permission dialog if the app context is null</li>
 	 * </ol>
 	 *
-	 * @param locationPermission The location permission setting that the user will be prompted for, could be {@link PlacesMonitorLocationPermission#WHILE_USING_APP} or {@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME}
+	 * @param locationPermission The location permission setting that the user will be prompted for, could be {@link PlacesMonitorLocationPermission#WHILE_USING_APP} or {@link PlacesMonitorLocationPermission#ALWAYS_ALLOW}
 	 */
 	public static void askPermission(final PlacesMonitorLocationPermission locationPermission) {
 		// for version below API 23, need not ask permission
@@ -221,13 +223,13 @@ public class PlacesActivity extends Activity {
 		return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M);
 	}
 
-
 	private static String[] getPermissionArray(PlacesMonitorLocationPermission placesMonitorLocationPermission) {
-		String[] permissions = new String[]{FINE_LOCATION};
-		if (PlacesMonitorLocationPermission.ALLOW_ALL_TIME == placesMonitorLocationPermission) {
-			permissions = new String[]{FINE_LOCATION, BACKGROUND_LOCATION};
+		List<String> permissionList = new ArrayList<String>();
+		permissionList.add(FINE_LOCATION);
+		if (PlacesMonitorLocationPermission.ALWAYS_ALLOW == placesMonitorLocationPermission) {
+			permissionList.add(BACKGROUND_LOCATION);
 		}
-		return permissions;
+		return permissionList.toArray(new String[permissionList.size()]);
 	}
 
 	// ========================================================================================

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
@@ -83,7 +83,7 @@ class PlacesLocationManager {
 			}
 		} else if (requestedLocationPermission == PlacesMonitorLocationPermission.ALLOW_ALL_TIME) {
 			if (!PlacesActivity.isBackgroundPermissionGranted()) {
-				Log.debug(PlacesMonitorConstants.LOG_TAG, "Requesting while in use location permission");
+				Log.debug(PlacesMonitorConstants.LOG_TAG, "Requesting allow all time location permission");
 				PlacesActivity.askPermission(requestedLocationPermission);
 				return;
 			}
@@ -174,7 +174,8 @@ class PlacesLocationManager {
 
 					case LocationSettingsStatusCodes.SETTINGS_CHANGE_UNAVAILABLE: {
 						Log.error(PlacesMonitorConstants.LOG_TAG,
-								"Failed to start location updates, status code : SETTINGS_CHANGE_UNAVAILABLE");
+								"Failed to start location updates, status code : SETTINGS_CHANGE_UNAVAILABLE. " +
+                                        "Location settings can't be changed to meet the requirements, no dialog pops up");
 						break;
 					}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
@@ -233,7 +233,12 @@ class PlacesLocationManager {
 
 
 	/**
-	 *  TODO: Docme
+	 * Handler for setting the location permission value to the location manager.
+	 * <p>
+	 *  This method saves the location permission value to persistence.
+	 *  If the monitoring has already been started, calling this method will then attempt to prompt the upgraded permission level to the user.
+	 *
+	 * @param placesMonitorLocationPermission the location permission level
 	 */
 	void setLocationPermission(PlacesMonitorLocationPermission placesMonitorLocationPermission) {
 		saveRequestedLocationPermission(placesMonitorLocationPermission);
@@ -419,7 +424,11 @@ class PlacesLocationManager {
 
 
 	/**
-	 * // TODO : DocMe
+	 * Persists the {@link #hasMonitoringStarted} in-memory variable to persistence
+	 * <p>
+	 * Saving of data will fail if the {@link SharedPreferences} or App's {@link Context} is null.
+	 *
+	 * @param hasMonitoringStarted value to be persisted
 	 */
 	void setHasMonitoringStarted(final boolean hasMonitoringStarted) {
 		this.hasMonitoringStarted = hasMonitoringStarted;
@@ -445,7 +454,11 @@ class PlacesLocationManager {
 
 
 	/**
-	 * // TODO : DocMe
+	 * Persists the {@link #requestedLocationPermission} in-memory variable to persistence
+	 * <p>
+	 * Saving of data will fail if the {@link SharedPreferences} or App's {@link Context} is null.
+	 *
+	 * @param locationPermission value to be persisted
 	 */
 	void saveRequestedLocationPermission(final PlacesMonitorLocationPermission locationPermission) {
 		this.requestedLocationPermission = locationPermission;

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
@@ -17,7 +17,6 @@ package com.adobe.marketing.mobile;
 
 import android.app.Activity;
 import android.app.PendingIntent;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -81,9 +80,9 @@ class PlacesLocationManager {
 				PlacesActivity.askPermission(requestedLocationPermission);
 				return;
 			}
-		} else if (requestedLocationPermission == PlacesMonitorLocationPermission.ALLOW_ALL_TIME) {
+		} else if (requestedLocationPermission == PlacesMonitorLocationPermission.ALWAYS_ALLOW) {
 			if (!PlacesActivity.isBackgroundPermissionGranted()) {
-				Log.debug(PlacesMonitorConstants.LOG_TAG, "Requesting allow all time location permission");
+				Log.debug(PlacesMonitorConstants.LOG_TAG, "Requesting allow always location permission");
 				PlacesActivity.askPermission(requestedLocationPermission);
 				return;
 			}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
@@ -41,25 +41,30 @@ public class PlacesMonitor {
 	}
 
 	/**
-	 * Use this API to set the type of location permission request, which user will be prompted during Places Monitor start.
+	 * This API sets the type of location permission request, for which user will be prompted for PlacesMonitor.start().
 	 * <p>
-	 * This API is applicable only Android 10+ devices. Call this method before the Places Monitor start, to set the appropriate authorization prompt to be shown to the user.
-	 * Calling this method while actively monitoring will upgrade the location permission level to the requested permission value.
-	 * This method has no effect if the requested authorization level is either already provided or denied by the application user.
+     * Tip: This API is effective only for devices that are on Android 10 and above.
+     *
+     * To set the appropriate authorization prompt to be shown to the user, call this API before the PlacesMonitor.start()
+	 * Calling this method, while actively monitoring will upgrade the location permission level to the requested permission value.
+     * If the requested authorization level is either already provided or denied by the application user,
+     * or if you attempt to downgrade permission from ALLOW_ALL_TIME to WHILE_USING_APP, this method has no effect.
+     *
 	 * {@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME} is the default location permission value.
 	 *
-	 * Following are the two different values of location permission that can be set by the API
+	 * Location permission can be set to one of the following values:
 	 * <ul>
 	 *     <li>{@link PlacesMonitorLocationPermission#WHILE_USING_APP}:
-	 *     Setting this value will prompt user to access device location only while using the application.
+	 *     This value prompts the user to access device location only while using the application.
+     *     An app is considered to be in use when the user is looking at the app on their device screen, for example an activity is running in the foreground.
 	 *     Make sure ACCESS_FINE_LOCATION permission is set in the App's Manifest file.
-	 *     Important : Geofences will not be registered when the user has just provided the "While using app" permission to device location.
-	 *     Hence, entry and exit events happening in the background will not be tracked by Places Monitor Extension
+	 *
+     *     Important: Geofences will not be registered with the operating system if the app user has granted the {@link PlacesMonitorLocationPermission#WHILE_USING_APP} permission.
+     *     As a result, the Places Monitor extension will not trigger entry/exit events on regions that are happening in the background.
 	 *
 	 *     <li>{@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME}:
-	 *     Setting this value will prompt user to access device location even when the application is backgrounded.
-	 *     Make sure ACCESS_BACKGROUND_LOCATION permission is set in the App's Manifest file.
-	 *
+	 *     This value prompts the user to access device location even when the application is backgrounded.
+	 *     Make sure ACCESS_BACKGROUND_LOCATION and ACCESS_FINE_LOCATION permission is set in the App's Manifest file.
 	 * </ul>
 	 * @param placesMonitorLocationPermission the location permission value
 	 */

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
@@ -41,11 +41,21 @@ public class PlacesMonitor {
 	}
 
 	/**
+	 * TODO : document me
+	 */
+	public static void setLocationPermission(final PlacesMonitorLocationPermission placesMonitorLocationPermission) {
+		EventData data = new EventData();
+		String locationPermissionString = placesMonitorLocationPermission == null ? null : placesMonitorLocationPermission.getValue();
+		data.putString(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_LOCATION_PERMISSION, locationPermissionString);
+		dispatchMonitorEvent(PlacesMonitorConstants.EVENTNAME_SET_LOCATION_PERMISSION, data);
+	}
+
+	/**
 	 * Start tracking the device's location and monitoring corresponding nearby POI's
 	 *
 	 */
 	public static void start() {
-		dispatchMonitorEvent(PlacesMonitorConstants.EVENTNAME_START);
+		dispatchMonitorEvent(PlacesMonitorConstants.EVENTNAME_START, new EventData());
 	}
 
 	/**
@@ -68,7 +78,7 @@ public class PlacesMonitor {
 	 * Immediately gets an update for the device's location
 	 */
 	public static void updateLocation() {
-		dispatchMonitorEvent(PlacesMonitorConstants.EVENTNAME_UPDATE);
+		dispatchMonitorEvent(PlacesMonitorConstants.EVENTNAME_UPDATE, new EventData());
 	}
 
 	/**
@@ -80,11 +90,11 @@ public class PlacesMonitor {
 	 *
 	 * @param eventName The name of the {@link Event} being dispatched
 	 */
-	private static void dispatchMonitorEvent(final String eventName) {
+	private static void dispatchMonitorEvent(final String eventName, final EventData eventData) {
 
 		final Event monitorEvent = new Event.Builder(eventName,
 				PlacesMonitorConstants.EventType.MONITOR,
-				PlacesMonitorConstants.EventSource.REQUEST_CONTENT).build();
+				PlacesMonitorConstants.EventSource.REQUEST_CONTENT).setData(eventData).build();
 
 
 		ExtensionErrorCallback<ExtensionError> extensionErrorCallback = new ExtensionErrorCallback<ExtensionError>() {

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
@@ -55,12 +55,13 @@ public class PlacesMonitor {
 	 *     Make sure ACCESS_FINE_LOCATION permission is set in the App's Manifest file.
 	 *     Important : Geofences will not be registered when the user has just provided the "While using app" permission to device location.
 	 *     Hence, entry and exit events happening in the background will not be tracked by Places Monitor Extension
-	 *     </>
+	 *
 	 *     <li>{@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME}:
 	 *     Setting this value will prompt user to access device location even when the application is backgrounded.
 	 *     Make sure ACCESS_BACKGROUND_LOCATION permission is set in the App's Manifest file.
-	 *     </>
+	 *
 	 * </ul>
+	 * @param placesMonitorLocationPermission the location permission value
 	 */
 	public static void setLocationPermission(final PlacesMonitorLocationPermission placesMonitorLocationPermission) {
 		EventData data = new EventData();

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
@@ -48,9 +48,9 @@ public class PlacesMonitor {
      * To set the appropriate authorization prompt to be shown to the user, call this API before the PlacesMonitor.start()
 	 * Calling this method, while actively monitoring will upgrade the location permission level to the requested permission value.
      * If the requested authorization level is either already provided or denied by the application user,
-     * or if you attempt to downgrade permission from ALLOW_ALL_TIME to WHILE_USING_APP, this method has no effect.
+     * or if you attempt to downgrade permission from ALWAYS_ALLOW to WHILE_USING_APP, this method has no effect.
      *
-	 * {@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME} is the default location permission value.
+	 * {@link PlacesMonitorLocationPermission#ALWAYS_ALLOW} is the default location permission value.
 	 *
 	 * Location permission can be set to one of the following values:
 	 * <ul>
@@ -62,7 +62,7 @@ public class PlacesMonitor {
      *     Important: Geofences will not be registered with the operating system if the app user has granted the {@link PlacesMonitorLocationPermission#WHILE_USING_APP} permission.
      *     As a result, the Places Monitor extension will not trigger entry/exit events on regions that are happening in the background.
 	 *
-	 *     <li>{@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME}:
+	 *     <li>{@link PlacesMonitorLocationPermission#ALWAYS_ALLOW}:
 	 *     This value prompts the user to access device location even when the application is backgrounded.
 	 *     Make sure ACCESS_BACKGROUND_LOCATION and ACCESS_FINE_LOCATION permission is set in the App's Manifest file.
 	 * </ul>

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
@@ -41,7 +41,26 @@ public class PlacesMonitor {
 	}
 
 	/**
-	 * TODO : document me
+	 * Use this API to set the type of location permission request, which user will be prompted during Places Monitor start.
+	 * <p>
+	 * This API is applicable only Android 10+ devices. Call this method before the Places Monitor start, to set the appropriate authorization prompt to be shown to the user.
+	 * Calling this method while actively monitoring will upgrade the location permission level to the requested permission value.
+	 * This method has no effect if the requested authorization level is either already provided or denied by the application user.
+	 * {@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME} is the default location permission value.
+	 *
+	 * Following are the two different values of location permission that can be set by the API
+	 * <ul>
+	 *     <li>{@link PlacesMonitorLocationPermission#WHILE_USING_APP}:
+	 *     Setting this value will prompt user to access device location only while using the application.
+	 *     Make sure ACCESS_FINE_LOCATION permission is set in the App's Manifest file.
+	 *     Important : Geofences will not be registered when the user has just provided the "While using app" permission to device location.
+	 *     Hence, entry and exit events happening in the background will not be tracked by Places Monitor Extension
+	 *     </>
+	 *     <li>{@link PlacesMonitorLocationPermission#ALLOW_ALL_TIME}:
+	 *     Setting this value will prompt user to access device location even when the application is backgrounded.
+	 *     Make sure ACCESS_BACKGROUND_LOCATION permission is set in the App's Manifest file.
+	 *     </>
+	 * </ul>
 	 */
 	public static void setLocationPermission(final PlacesMonitorLocationPermission placesMonitorLocationPermission) {
 		EventData data = new EventData();

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
@@ -27,11 +27,15 @@ final class PlacesMonitorConstants {
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";
 	static final String EVENTNAME_STOP = "stop monitoring";
-	static final String EVENTNAME_UPDATE = "update location";
+	static final String EVENTNAME_UPDATE = "update location now";
+	static final String EVENTNAME_SET_LOCATION_PERMISSION = "set location permission";
+
 	static final int NEARBY_GEOFENCES_COUNT = 20;
 
 	static final String INTERNAL_INTENT_ACTION_LOCATION = "intentactionlocation";
 	static final String INTERNAL_INTENT_ACTION_GEOFENCE = "intentactiongeofence";
+	static final String INTENT_ACTION_PERMISSION_GRANTED = "permissionreceived";
+	static final String INTENT_ACTION_PERMISSION_DENIED = "permissiondenied";
 
 	static final class Location {
 		static final int REQUEST_INTERVAL = 3600;				// 1 hour
@@ -53,6 +57,7 @@ final class PlacesMonitorConstants {
 
 	static final class EventDataKeys {
 		static final String EVENT_DATA_CLEAR	= "clearclientdata";
+		static final String EVENT_DATA_LOCATION_PERMISSION = "locationpermission";
 		private EventDataKeys() {
 		}
 	}
@@ -77,6 +82,7 @@ final class PlacesMonitorConstants {
 		static final String MASTER_KEY = "com.adobe.placesMonitor";
 		static final String USERWITHIN_GEOFENCES_KEY = "adb_userWithinGeofences";
 		static final String HAS_MONITORING_STARTED_KEY = "adb_hasMonitoringStarted";
+		static final String LOCATION_PERMISSION_KEY = "adb_hasMonitoringStarted";
 		private SharedPreference() {
 		}
 	}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
@@ -22,7 +22,7 @@ final class PlacesMonitorConstants {
 	static final String LOG_TAG = PlacesMonitor.class.getSimpleName();
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
-	static final String EXTENSION_VERSION = "1.0.2";
+	static final String EXTENSION_VERSION = "2.1.0";
 
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
@@ -82,7 +82,7 @@ final class PlacesMonitorConstants {
 		static final String MASTER_KEY = "com.adobe.placesMonitor";
 		static final String USERWITHIN_GEOFENCES_KEY = "adb_userWithinGeofences";
 		static final String HAS_MONITORING_STARTED_KEY = "adb_hasMonitoringStarted";
-		static final String LOCATION_PERMISSION_KEY = "adb_hasMonitoringStarted";
+		static final String LOCATION_PERMISSION_KEY = "adb_locationPermission";
 		private SharedPreference() {
 		}
 	}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -139,6 +139,8 @@ class PlacesMonitorInternal extends Extension {
 
 		LocalBroadcastManager.getInstance(context).registerReceiver(permissionDeniedReceiver,
 				new IntentFilter(PlacesMonitorConstants.INTENT_ACTION_PERMISSION_DENIED));
+
+		Log.debug("Places Monitor extension successfully initialized. Version  %s", PlacesMonitorConstants.EXTENSION_VERSION);
 	}
 
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -51,6 +51,21 @@ class PlacesMonitorInternal extends Extension {
 		}
 	};
 
+	private BroadcastReceiver permissionGrantedReceiver = new BroadcastReceiver() {
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			locationManager.beginLocationTracking();
+		}
+	};
+
+	private BroadcastReceiver permissionDeniedReceiver = new BroadcastReceiver() {
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			locationManager.stopMonitoring();
+			geofenceManager.stopMonitoringFences(true);
+		}
+	};
+
 	/**
 	 * Constructor.
 	 *
@@ -118,6 +133,12 @@ class PlacesMonitorInternal extends Extension {
 
 		LocalBroadcastManager.getInstance(context).registerReceiver(internalGeofenceReceiver,
 				new IntentFilter(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE));
+
+		LocalBroadcastManager.getInstance(context).registerReceiver(permissionGrantedReceiver,
+				new IntentFilter(PlacesMonitorConstants.INTENT_ACTION_PERMISSION_GRANTED));
+
+		LocalBroadcastManager.getInstance(context).registerReceiver(permissionDeniedReceiver,
+				new IntentFilter(PlacesMonitorConstants.INTENT_ACTION_PERMISSION_DENIED));
 	}
 
 
@@ -271,7 +292,10 @@ class PlacesMonitorInternal extends Extension {
 			stopMonitoring(shouldClear);
 		} else if (PlacesMonitorConstants.EVENTNAME_UPDATE.equals(eventName)) {
 			updateLocation();
-		} else {
+		} else if (PlacesMonitorConstants.EVENTNAME_SET_LOCATION_PERMISSION.equals(eventName)) {
+			setLocationPermission(event.getEventData());
+		}
+		else {
 			Log.warning(PlacesMonitorConstants.LOG_TAG,
 						"PlacesMonitorInternal : Could not process places monitor request event, Invalid/Unknown event name");
 		}
@@ -355,6 +379,16 @@ class PlacesMonitorInternal extends Extension {
 		locationManager.updateLocation();
 	}
 
+	private void setLocationPermission(final Map<String,Object> eventData) {
+		if(eventData == null || eventData.isEmpty()) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "Invalid location permission value set. Ignoring setLocationPermission API call");
+			return;
+		}
+
+		String locationPermissionString = (String)eventData.get(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_LOCATION_PERMISSION);
+		PlacesMonitorLocationPermission placesMonitorLocationPermission = PlacesMonitorLocationPermission.fromString(locationPermissionString);
+		locationManager.setLocationPermission(placesMonitorLocationPermission);
+	}
 
 
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
@@ -33,14 +33,14 @@ public enum PlacesMonitorLocationPermission {
      * An app is considered to be in use when the user is looking at the app on their device screen (i.e) an activity is running in the foreground.
      * <p>
      * Important:  Geofences will not get registered with the Operating system if the app user has granted "While using app" permission.
-     * "Allow all time" permission is mandatory for registering and getting the entry/exit triggers on the geofence from the OS.
+     * "Always Allow" permission is mandatory for registering and getting the entry/exit triggers on the geofence from the OS.
      */
     WHILE_USING_APP("whileusingapp"),
 
     /**
      * Permission for Places Monitor to access location in foreground and background.
      */
-    ALLOW_ALL_TIME("allowalltime");
+    ALWAYS_ALLOW("alwaysAllow");
 
     private final String value;
 
@@ -59,7 +59,7 @@ public enum PlacesMonitorLocationPermission {
     /**
      * Returns a {@link PlacesMonitorLocationPermission} object based on the provided {@code text}.
      * <p>
-     * If the text provided is not valid, {@link #ALLOW_ALL_TIME} will be returned.
+     * If the text provided is not valid, {@link #ALWAYS_ALLOW} will be returned.
      *
      * @param text {@link String} to be converted to a {@code PlacesMonitorLocationPermission} object
      * @return {@code PlacesMonitorLocationPermission} object equivalent to the provided text
@@ -71,6 +71,6 @@ public enum PlacesMonitorLocationPermission {
             }
         }
 
-        return ALLOW_ALL_TIME;
+        return ALWAYS_ALLOW;
     }
 }

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
@@ -17,14 +17,23 @@ package com.adobe.marketing.mobile;
 
 /**
  * Represents the possible location permission settings for Android.
- *<p>
+ * <p>
  * Apps that use location services must request location permissions. On a device that runs Android 10 (API level 29) or higher
- * users see the dialog to indicate that your app is requesting a location permission.  Android Q have added the ability for users to control which apps can access their device location when they're not using the app.
+ * users see the dialog to indicate that your app is requesting a location permission.
+ * <p>
+ * Before Android 10 location permission was a binary choice, either allow or deny access to their device location. If the user has provided the access location,
+ * the app could get location information both in foreground as well as background.
+ * <p>
+ * Android 10 have added the ability for users to control which apps can access their device location when they're not using the app.
  * A new permission "Allow only while using the app" is added.
  */
 public enum PlacesMonitorLocationPermission {
     /**
      * Permission for Places Monitor to access location while using application.
+     * An app is considered to be in use when the user is looking at the app on their device screen (i.e) an activity is running in the foreground.
+     * <p>
+     * Important:  Geofences will not get registered with the Operating system if the user has provided "While using the app" permission.
+     * "Allow all the time" permission is mandatory for registering and getting the entry/exit triggers on the geofence from the OS.
      */
     WHILE_USING_APP("whileusingapp"),
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
@@ -1,0 +1,75 @@
+/*
+ * ***********************************************************************
+ * ADOBE CONFIDENTIAL
+ * ___________________
+ *
+ * Copyright 2018 Adobe Systems Incorporated
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
+ *************************************************************************
+ */
+
+package com.adobe.marketing.mobile;
+
+/**
+ * Represents the possible location permission settings for Android.
+ *<p>
+ * Apps that use location services must request location permissions. On a device that runs Android 10 (API level 29) or higher
+ * users see the dialog to indicate that your app is requesting a location permission.  Android Q have added the ability for users to control which apps can access their device location when they're not using the app.
+ * A new permission "Allow only while using the app" is added.
+ *
+ *
+ * <p>
+ *
+ */
+public enum PlacesMonitorLocationPermission {
+    /**
+     * Permission for Places Monitor to access location while using application.
+     */
+    WHILE_USING_APP("whileusingapp"),
+
+    /**
+     * Permission for Places Monitor to access location in foreground and background.
+     */
+    ALLOW_ALL_TIME("allowalltime");
+
+    private final String value;
+
+    PlacesMonitorLocationPermission(final String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the string value for this enum type.
+     * @return the string name for this enum type.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Returns a {@link PlacesMonitorLocationPermission} object based on the provided {@code text}.
+     * <p>
+     * If the text provided is not valid, {@link #ALLOW_ALL_TIME} will be returned.
+     *
+     * @param text {@link String} to be converted to a {@code PlacesMonitorLocationPermission} object
+     * @return {@code PlacesMonitorLocationPermission} object equivalent to the provided text
+     */
+    static PlacesMonitorLocationPermission fromString(final String text) {
+        for (PlacesMonitorLocationPermission b : PlacesMonitorLocationPermission.values()) {
+            if (b.value.equalsIgnoreCase(text)) {
+                return b;
+            }
+        }
+
+        return ALLOW_ALL_TIME;
+    }
+}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
@@ -1,21 +1,17 @@
 /*
- * ***********************************************************************
- * ADOBE CONFIDENTIAL
- * ___________________
- *
- * Copyright 2018 Adobe Systems Incorporated
- * All Rights Reserved.
- *
- * NOTICE:  All information contained herein is, and remains
- * the property of Adobe Systems Incorporated and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to Adobe Systems Incorporated and its
- * suppliers and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this material
- * is strictly forbidden unless prior written permission is obtained
- * from Adobe Systems Incorporated.
- *************************************************************************
- */
+ Copyright 2019 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+//
+// PlacesMonitorLocationPermission.java
+//
 
 package com.adobe.marketing.mobile;
 
@@ -25,10 +21,6 @@ package com.adobe.marketing.mobile;
  * Apps that use location services must request location permissions. On a device that runs Android 10 (API level 29) or higher
  * users see the dialog to indicate that your app is requesting a location permission.  Android Q have added the ability for users to control which apps can access their device location when they're not using the app.
  * A new permission "Allow only while using the app" is added.
- *
- *
- * <p>
- *
  */
 public enum PlacesMonitorLocationPermission {
     /**

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorLocationPermission.java
@@ -32,8 +32,8 @@ public enum PlacesMonitorLocationPermission {
      * Permission for Places Monitor to access location while using application.
      * An app is considered to be in use when the user is looking at the app on their device screen (i.e) an activity is running in the foreground.
      * <p>
-     * Important:  Geofences will not get registered with the Operating system if the user has provided "While using the app" permission.
-     * "Allow all the time" permission is mandatory for registering and getting the entry/exit triggers on the geofence from the OS.
+     * Important:  Geofences will not get registered with the Operating system if the app user has granted "While using app" permission.
+     * "Allow all time" permission is mandatory for registering and getting the entry/exit triggers on the geofence from the OS.
      */
     WHILE_USING_APP("whileusingapp"),
 

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
@@ -20,7 +20,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.graphics.Point;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
@@ -224,7 +223,7 @@ public class PlacesActivityTests {
 		// setup
 		final ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
 		// test
-		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
 		verify(context, times(1)).startActivity(intentArgumentCaptor.capture());
@@ -238,7 +237,7 @@ public class PlacesActivityTests {
 		setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 22);
 
 		// test
-		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
 		verify(context, times(0)).startActivity(any(Intent.class));
@@ -250,7 +249,7 @@ public class PlacesActivityTests {
 		Mockito.when(App.getAppContext()).thenReturn(null);
 
 		// test
-		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
 		verify(context, times(0)).startActivity(any(Intent.class));
@@ -262,7 +261,7 @@ public class PlacesActivityTests {
 	@Test
 	public void test_onCreate_willRequestPermission_AllowAllTime() {
 		// setup
-		Mockito.when(mockExtra.get(INTENT_PERMISSION_KEY)).thenReturn(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		Mockito.when(mockExtra.get(INTENT_PERMISSION_KEY)).thenReturn(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// test
 		Mockito.doCallRealMethod().when(placesActivity).onCreate(mockBundle);

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
@@ -259,7 +259,7 @@ public class PlacesActivityTests {
 	// onCreate - OverriddenMethod
 	// ========================================================================================
 	@Test
-	public void test_onCreate_willRequestPermission_AllowAllTime() {
+	public void test_onCreate_willRequestPermission_AlwaysAllow() {
 		// setup
 		Mockito.when(mockExtra.get(INTENT_PERMISSION_KEY)).thenReturn(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
@@ -20,9 +20,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.graphics.Point;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.LocalBroadcastManager;
 import android.view.Window;
 import android.view.WindowManager;
 
@@ -53,15 +55,17 @@ import static org.mockito.ArgumentMatchers.*;
 
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Context.class, App.class, ActivityCompat.class, Build.class, PlacesMonitor.class, LocationSettingsStates.class})
+@PrepareForTest({Context.class, App.class, ActivityCompat.class, Build.class, PlacesMonitor.class, LocationSettingsStates.class, LocalBroadcastManager.class, Intent.class})
 public class PlacesActivityTests {
 	private static final String FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
+	private static final String BACKGROUND_LOCATION = Manifest.permission.ACCESS_BACKGROUND_LOCATION;
+	private static final String INTENT_PERMISSION_KEY = "intent permission key";
 
 	@Mock
 	Context context;
 
 	@Mock
-	Bundle mockBundle;
+	Bundle mockBundle, mockExtra;
 
 	@Mock
 	Window window;
@@ -73,8 +77,10 @@ public class PlacesActivityTests {
 	Intent mockIntent;
 
 	@Mock
-	LocationSettingsStates locationSettingsStates;
+	LocalBroadcastManager localBroadcastManager;
 
+	@Mock
+	LocationSettingsStates locationSettingsStates;
 
 	@Before
 	public void before() throws Exception {
@@ -93,6 +99,11 @@ public class PlacesActivityTests {
 
 		// mock other methods
 		Mockito.when(placesActivity.getWindow()).thenReturn(window);
+		Mockito.when(placesActivity.getIntent()).thenReturn(mockIntent);
+		Mockito.when(mockIntent.getExtras()).thenReturn(mockExtra);
+
+		PowerMockito.mockStatic(LocalBroadcastManager.class);
+		PowerMockito.when(LocalBroadcastManager.class, "getInstance", any()).thenReturn(localBroadcastManager);
 	}
 
 
@@ -101,12 +112,12 @@ public class PlacesActivityTests {
 	// ========================================================================================
 
 	@Test
-	public void test_isFineLocationPermissionGranted_for_OSLessThanAndroidM() throws Exception {
+	public void test_isWhileInUsePermissionGranted_for_OSLessThanAndroidM() throws Exception {
 		// setup
 		setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 22);
 
 		// test
-		boolean isGranted = PlacesActivity.isFineLocationPermissionGranted();
+		boolean isGranted = PlacesActivity.isWhileInUsePermissionGranted();
 
 		// verify
 		assertTrue(isGranted);
@@ -114,12 +125,12 @@ public class PlacesActivityTests {
 
 
 	@Test
-	public void test_isFineLocationPermissionGranted_when_AppContextNull() throws Exception {
+	public void test_isWhileInUsePermissionGranted_when_AppContextNull() throws Exception {
 		// setup
 		Mockito.when(App.getAppContext()).thenReturn(null);
 
 		// test
-		boolean isGranted = PlacesActivity.isFineLocationPermissionGranted();
+		boolean isGranted = PlacesActivity.isWhileInUsePermissionGranted();
 
 		// verify
 		assertFalse(isGranted);
@@ -127,24 +138,78 @@ public class PlacesActivityTests {
 
 
 	@Test
-	public void test_isFineLocationPermissionGranted_when_PermissionGranted() throws Exception {
+	public void test_isWhileInUsePermissionGranted_when_PermissionGranted() throws Exception {
 		// setup
 		Mockito.when(ActivityCompat.checkSelfPermission(context, FINE_LOCATION)).thenReturn(PackageManager.PERMISSION_GRANTED);
 
 		// test
-		boolean isGranted = PlacesActivity.isFineLocationPermissionGranted();
+		boolean isGranted = PlacesActivity.isWhileInUsePermissionGranted();
 
 		// verify
 		assertTrue(isGranted);
 	}
 
 	@Test
-	public void test_isFineLocationPermissionGranted_when_PermissionDenied() throws Exception {
+	public void test_isWhileInUsePermissionGranted_when_PermissionDenied() throws Exception {
 		// setup
 		Mockito.when(ActivityCompat.checkSelfPermission(context, FINE_LOCATION)).thenReturn(PackageManager.PERMISSION_DENIED);
 
 		// test
-		boolean isGranted = PlacesActivity.isFineLocationPermissionGranted();
+		boolean isGranted = PlacesActivity.isWhileInUsePermissionGranted();
+
+		// verify
+		assertFalse(isGranted);
+	}
+
+	// ========================================================================================
+	// isBackgroundPermissionGranted
+	// ========================================================================================
+
+	@Test
+	public void test_isBackgroundPermissionGranted_for_OSLessThanAndroidM() throws Exception {
+		// setup
+		setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 22);
+
+		// test
+		boolean isGranted = PlacesActivity.isBackgroundPermissionGranted();
+
+		// verify
+		assertTrue(isGranted);
+	}
+
+
+	@Test
+	public void test_isBackgroundPermissionGranted_when_AppContextNull() throws Exception {
+		// setup
+		Mockito.when(App.getAppContext()).thenReturn(null);
+
+		// test
+		boolean isGranted = PlacesActivity.isBackgroundPermissionGranted();
+
+		// verify
+		assertFalse(isGranted);
+	}
+
+
+	@Test
+	public void test_isBackgroundPermissionGranted_when_PermissionGranted() throws Exception {
+		// setup
+		Mockito.when(ActivityCompat.checkSelfPermission(context, BACKGROUND_LOCATION)).thenReturn(PackageManager.PERMISSION_GRANTED);
+
+		// test
+		boolean isGranted = PlacesActivity.isBackgroundPermissionGranted();
+
+		// verify
+		assertTrue(isGranted);
+	}
+
+	@Test
+	public void test_isBackgroundPermissionGranted_when_PermissionDenied() throws Exception {
+		// setup
+		Mockito.when(ActivityCompat.checkSelfPermission(context, BACKGROUND_LOCATION)).thenReturn(PackageManager.PERMISSION_DENIED);
+
+		// test
+		boolean isGranted = PlacesActivity.isBackgroundPermissionGranted();
 
 		// verify
 		assertFalse(isGranted);
@@ -159,7 +224,7 @@ public class PlacesActivityTests {
 		// setup
 		final ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
 		// test
-		PlacesActivity.askPermission();
+		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
 
 		// verify
 		verify(context, times(1)).startActivity(intentArgumentCaptor.capture());
@@ -173,7 +238,7 @@ public class PlacesActivityTests {
 		setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 22);
 
 		// test
-		PlacesActivity.askPermission();
+		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
 
 		// verify
 		verify(context, times(0)).startActivity(any(Intent.class));
@@ -185,7 +250,7 @@ public class PlacesActivityTests {
 		Mockito.when(App.getAppContext()).thenReturn(null);
 
 		// test
-		PlacesActivity.askPermission();
+		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
 
 		// verify
 		verify(context, times(0)).startActivity(any(Intent.class));
@@ -195,7 +260,10 @@ public class PlacesActivityTests {
 	// onCreate - OverriddenMethod
 	// ========================================================================================
 	@Test
-	public void test_onCreate_willRequestPermission() {
+	public void test_onCreate_willRequestPermission_AllowAllTime() {
+		// setup
+		Mockito.when(mockExtra.get(INTENT_PERMISSION_KEY)).thenReturn(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+
 		// test
 		Mockito.doCallRealMethod().when(placesActivity).onCreate(mockBundle);
 		placesActivity.onCreate(mockBundle);
@@ -203,7 +271,22 @@ public class PlacesActivityTests {
 		// verify
 		verify(window, times(1)).addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
 		verifyStatic(ActivityCompat.class, Mockito.times(1));
-		ActivityCompat.requestPermissions(eq(placesActivity), any(String[].class), anyInt());
+		ActivityCompat.requestPermissions(eq(placesActivity), eq(new String[]{FINE_LOCATION, BACKGROUND_LOCATION}), eq(PlacesMonitorTestConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE));
+	}
+
+	@Test
+	public void test_onCreate_willRequestPermission_WhenInUse() {
+		// setup
+		Mockito.when(mockExtra.get(INTENT_PERMISSION_KEY)).thenReturn(PlacesMonitorLocationPermission.WHILE_USING_APP);
+
+		// test
+		Mockito.doCallRealMethod().when(placesActivity).onCreate(mockBundle);
+		placesActivity.onCreate(mockBundle);
+
+		// verify
+		verify(window, times(1)).addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
+		verifyStatic(ActivityCompat.class, Mockito.times(1));
+		ActivityCompat.requestPermissions(eq(placesActivity), eq(new String[]{FINE_LOCATION}), eq(PlacesMonitorTestConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE));
 	}
 
 	@Test
@@ -238,7 +321,7 @@ public class PlacesActivityTests {
 	}
 
 	@Test
-	public void test_onRequestPermissionsResult_when_PermissionGranted() {
+	public void test_onRequestPermissionsResult_when_PermissionGranted() throws Exception{
 		// test
 		Mockito.doCallRealMethod().when(placesActivity).onRequestPermissionsResult(anyInt(),  any(String[].class),
 				any(int[].class));
@@ -333,13 +416,7 @@ public class PlacesActivityTests {
 	}
 
 	private void verifyOnPermissionDenied() {
-		// verify start is not called
-		verifyStatic(PlacesMonitor.class, Mockito.times(0));
-		PlacesMonitor.start();
-
-		// verify stop monitoring is called
-		verifyStatic(PlacesMonitor.class, Mockito.times(1));
-		PlacesMonitor.stop(true);
+		verify(localBroadcastManager,times(1)).sendBroadcast(any(Intent.class));
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();
@@ -347,13 +424,7 @@ public class PlacesActivityTests {
 
 
 	private void verifyOnPermissionGranted() {
-		// verify start is called
-		verifyStatic(PlacesMonitor.class, Mockito.times(1));
-		PlacesMonitor.start();
-
-		// verify stop monitoring is not called
-		verifyStatic(PlacesMonitor.class, Mockito.times(0));
-		PlacesMonitor.stop(true);
+		verify(localBroadcastManager,times(1)).sendBroadcast(any(Intent.class));
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationManagerTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationManagerTests.java
@@ -340,7 +340,7 @@ public class PlacesLocationManagerTests {
 	}
 
     @Test
-    public void test_startMonitoring_when_AllowAllTime_Requested_WhileInUsePermissionGranted() {
+    public void test_startMonitoring_when_AlwaysAllow_Requested_WhileInUsePermissionGranted() {
         // setup
         Mockito.when(PlacesActivity.isWhileInUsePermissionGranted()).thenReturn(true);
 		Mockito.when(PlacesActivity.isBackgroundPermissionGranted()).thenReturn(false);
@@ -358,7 +358,7 @@ public class PlacesLocationManagerTests {
     }
 
 	@Test
-	public void test_startMonitoring_when_AllowAllTimeRequested_BackgroundPermissionGranted() {
+	public void test_startMonitoring_when_AlwaysAllow_Requested_BackgroundPermissionGranted() {
 		// setup
 		Mockito.when(PlacesActivity.isWhileInUsePermissionGranted()).thenReturn(true);
 		Mockito.when(PlacesActivity.isBackgroundPermissionGranted()).thenReturn(true);

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationManagerTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationManagerTests.java
@@ -344,14 +344,14 @@ public class PlacesLocationManagerTests {
         // setup
         Mockito.when(PlacesActivity.isWhileInUsePermissionGranted()).thenReturn(true);
 		Mockito.when(PlacesActivity.isBackgroundPermissionGranted()).thenReturn(false);
-        Whitebox.setInternalState(locationManager, "requestedLocationPermission", PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+        Whitebox.setInternalState(locationManager, "requestedLocationPermission", PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
         // test
         locationManager.startMonitoring();
 
         // verify the SDK asks from background permission
         verifyStatic(PlacesActivity.class, Mockito.times(1));
-        PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+        PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify if location updates are not requested
 		verify(locationManager, times(0)).beginLocationTracking();
@@ -362,14 +362,14 @@ public class PlacesLocationManagerTests {
 		// setup
 		Mockito.when(PlacesActivity.isWhileInUsePermissionGranted()).thenReturn(true);
 		Mockito.when(PlacesActivity.isBackgroundPermissionGranted()).thenReturn(true);
-		Whitebox.setInternalState(locationManager, "requestedLocationPermission", PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		Whitebox.setInternalState(locationManager, "requestedLocationPermission", PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// test
 		locationManager.startMonitoring();
 
 		// verify the SDK does not ask anymore permissions
 		verifyStatic(PlacesActivity.class, Mockito.times(0));
-		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		PlacesActivity.askPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify if location updates are requested
 		verify(locationManager, times(1)).beginLocationTracking();
@@ -571,10 +571,10 @@ public class PlacesLocationManagerTests {
 		Whitebox.setInternalState(locationManager, "hasMonitoringStarted", false);
 
 		// test
-		locationManager.setLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		locationManager.setLocationPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
-		verify(locationManager, times(1)).saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		verify(locationManager, times(1)).saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 		verify(locationManager, times(0)).startMonitoring();
 	}
 
@@ -584,10 +584,10 @@ public class PlacesLocationManagerTests {
 		Whitebox.setInternalState(locationManager, "hasMonitoringStarted", true);
 
 		// test
-		locationManager.setLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		locationManager.setLocationPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
-		verify(locationManager, times(1)).saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		verify(locationManager, times(1)).saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 		verify(locationManager, times(1)).startMonitoring();
 	}
 
@@ -658,12 +658,12 @@ public class PlacesLocationManagerTests {
 	@Test
 	public void test_saveRequestedLocationPermission() {
 		// test
-		locationManager.saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		locationManager.saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
-		verify(mockSharedPreferenceEditor, times(1)).putString(PlacesMonitorTestConstants.SharedPreference.LOCATION_PERMISSION_KEY, PlacesMonitorLocationPermission.ALLOW_ALL_TIME.getValue());
+		verify(mockSharedPreferenceEditor, times(1)).putString(PlacesMonitorTestConstants.SharedPreference.LOCATION_PERMISSION_KEY, PlacesMonitorLocationPermission.ALWAYS_ALLOW.getValue());
 		PlacesMonitorLocationPermission locationPermission = Whitebox.getInternalState(locationManager, "requestedLocationPermission");
-		assertEquals(PlacesMonitorLocationPermission.ALLOW_ALL_TIME,locationPermission);
+		assertEquals(PlacesMonitorLocationPermission.ALWAYS_ALLOW,locationPermission);
 	}
 
 	@Test
@@ -672,12 +672,12 @@ public class PlacesLocationManagerTests {
 		Mockito.when(context.getSharedPreferences(PlacesMonitorTestConstants.SharedPreference.MASTER_KEY,
 				0)).thenReturn(null);
 		// test
-		locationManager.saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		locationManager.saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
-		verify(mockSharedPreferenceEditor, times(0)).putString(PlacesMonitorTestConstants.SharedPreference.LOCATION_PERMISSION_KEY, PlacesMonitorLocationPermission.ALLOW_ALL_TIME.getValue());
+		verify(mockSharedPreferenceEditor, times(0)).putString(PlacesMonitorTestConstants.SharedPreference.LOCATION_PERMISSION_KEY, PlacesMonitorLocationPermission.ALWAYS_ALLOW.getValue());
 		PlacesMonitorLocationPermission locationPermission = Whitebox.getInternalState(locationManager, "requestedLocationPermission");
-		assertEquals(PlacesMonitorLocationPermission.ALLOW_ALL_TIME,locationPermission);
+		assertEquals(PlacesMonitorLocationPermission.ALWAYS_ALLOW,locationPermission);
 	}
 
 
@@ -687,12 +687,12 @@ public class PlacesLocationManagerTests {
 		Mockito.when(mockSharedPreference.edit()).thenReturn(null);
 
 		// test
-		locationManager.saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME);
+		locationManager.saveRequestedLocationPermission(PlacesMonitorLocationPermission.ALWAYS_ALLOW);
 
 		// verify
-		verify(mockSharedPreferenceEditor, times(0)).putString(PlacesMonitorTestConstants.SharedPreference.LOCATION_PERMISSION_KEY, PlacesMonitorLocationPermission.ALLOW_ALL_TIME.getValue());
+		verify(mockSharedPreferenceEditor, times(0)).putString(PlacesMonitorTestConstants.SharedPreference.LOCATION_PERMISSION_KEY, PlacesMonitorLocationPermission.ALWAYS_ALLOW.getValue());
 		PlacesMonitorLocationPermission locationPermission = Whitebox.getInternalState(locationManager, "requestedLocationPermission");
-		assertEquals(PlacesMonitorLocationPermission.ALLOW_ALL_TIME,locationPermission);
+		assertEquals(PlacesMonitorLocationPermission.ALWAYS_ALLOW,locationPermission);
 	}
 
 	// ========================================================================================

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
@@ -101,7 +101,7 @@ final class PlacesMonitorTestConstants {
 		static final String MASTER_KEY = "com.adobe.placesMonitor";
 		static final String USERWITHIN_GEOFENCES_KEY = "adb_userWithinGeofences";
 		static final String HAS_MONITORING_STARTED_KEY = "adb_hasMonitoringStarted";
-		static final String LOCATION_PERMISSION_KEY = "adb_hasMonitoringStarted";
+		static final String LOCATION_PERMISSION_KEY = "adb_locationPermission";
 		private SharedPreference() {
 		}
 	}

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
@@ -27,11 +27,14 @@ final class PlacesMonitorTestConstants {
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";
 	static final String EVENTNAME_STOP = "stop monitoring";
-	static final String EVENTNAME_UPDATE = "update location";
+	static final String EVENTNAME_UPDATE = "update location now";
+	static final String EVENTNAME_SET_LOCATION_PERMISSION = "set location permission";
 	static final int NEARBY_GEOFENCES_COUNT = 20;
 
 	static final String INTERNAL_INTENT_ACTION_LOCATION = "intentactionlocation";
 	static final String INTERNAL_INTENT_ACTION_GEOFENCE = "intentactiongeofence";
+	static final String INTENT_ACTION_PERMISSION_GRANTED = "permissionreceived";
+	static final String INTENT_ACTION_PERMISSION_DENIED = "permissiondenied";
 
 	static final class Location {
 		static final int REQUEST_INTERVAL = 3600;				// 1 hour
@@ -55,6 +58,7 @@ final class PlacesMonitorTestConstants {
 
 		static final String EVENT_DATA_CLEAR	= "clearclientdata";
 		static final String NEAR_BY_PLACES_LIST = "nearbyplaceslist";
+		static final String EVENT_DATA_LOCATION_PERMISSION = "locationpermission";
 		static final String REQUEST_TYPE = "requesttype";
 		static final String REQUEST_TYPE_GET_NEARBY_PLACES = "requestgetnearbyplaces";
 		static final String REQUEST_TYPE_PROCESS_REGION_EVENT = "requestprocessregionevent";
@@ -96,6 +100,8 @@ final class PlacesMonitorTestConstants {
 	static final class SharedPreference {
 		static final String MASTER_KEY = "com.adobe.placesMonitor";
 		static final String USERWITHIN_GEOFENCES_KEY = "adb_userWithinGeofences";
+		static final String HAS_MONITORING_STARTED_KEY = "adb_hasMonitoringStarted";
+		static final String LOCATION_PERMISSION_KEY = "adb_hasMonitoringStarted";
 		private SharedPreference() {
 		}
 	}

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
@@ -21,7 +21,7 @@ final class PlacesMonitorTestConstants {
 
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
-	static final String EXTENSION_VERSION = "1.0.2";
+	static final String EXTENSION_VERSION = "2.1.0";
 	static final String CONTINUOUS_MONITORING = "continuousmonitoring";
 
 	// event names for places monitor request content

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTests.java
@@ -197,6 +197,38 @@ public class PlacesMonitorTests {
 					 event.getSource());
 	}
 
+
+	// ========================================================================================
+	// setLocationPermission
+	// ========================================================================================
+
+	@Test
+	public void test_setLocationPermission() {
+		// setup
+		Mockito.when(MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class))).thenReturn(true);
+
+		// setup argument captors
+		final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+		final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
+
+		// test
+		PlacesMonitor.setLocationPermission(PlacesMonitorLocationPermission.WHILE_USING_APP);
+
+		// The start event should be dispatched
+		verifyStatic(MobileCore.class, Mockito.times(1));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+
+		// verify dispatched event
+		Event event = eventCaptor.getValue();
+		assertNotNull("The dispatched event should not be null", event);
+		assertEquals("the event name should be correct", PlacesMonitorTestConstants.EVENTNAME_SET_LOCATION_PERMISSION, event.getName());
+		assertEquals("the event type should be correct", PlacesMonitorTestConstants.EventType.MONITOR, event.getType());
+		assertEquals("the event source should be correct", PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT,
+				event.getSource());
+		assertEquals("the event data size should be correct",1, event.getEventData().size());
+		assertEquals("the event data should be correct",PlacesMonitorLocationPermission.WHILE_USING_APP.getValue(), event.getEventData().get(PlacesMonitorTestConstants.EventDataKeys.EVENT_DATA_LOCATION_PERMISSION));
+	}
+
 	// ========================================================================================
 	// dispatchEventCallback
 	// ========================================================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adding an API to facilitate prompting for required permission level in Android 10+ devices.

<!--- Describe your changes in detail -->

The following API is added to the Places Monitor extension.

```
public static void setLocationPermission(final PlacesMonitorLocationPermission placesMonitorLocationPermission)
```


**Sample Usage:**

To request for WhenInUse permission

```
// set the location permission
PlacesMonitor.setLocationPermission(PlacesMonitorLocationPermission.WHILE_USING_APP);
// start monitoring
PlacesMonitor.start()

```

Further when its required to upgrade to Always Allow authorization
```
// upgrade the permission level
PlacesMonitor.setLocationPermission(PlacesMonitorLocationPermission.ALLOW_ALL_TIME
);
```


## Related Issue
https://jira.corp.adobe.com/browse/AMSDK-8709

## Motivation and Context
Places monitor being flexible enough to request and upgrade permission as and when the app user needs it.

## How Has This Been Tested?

This feature is tested on emulator version (API 29, 28, 22) by calling the setLocationPermission with different values.

## Screenshots (if appropriate):

**Android 9 - Location dialog** 
<img width="442" alt="Screen Shot 2019-10-02 at 11 48 53 AM" src="https://user-images.githubusercontent.com/8909148/66073457-e91e7880-e50b-11e9-9d44-a89b24e87720.png">


**Android 10 dialog - WhenInUse permission** 
<img width="429" alt="Screen Shot 2019-10-02 at 11 53 18 AM" src="https://user-images.githubusercontent.com/8909148/66073490-f63b6780-e50b-11e9-8ee5-b8b370880217.png">


**Android 10 dialog - Always Allow permission** 
<img width="429" alt="Screen Shot 2019-10-02 at 11 53 34 AM" src="https://user-images.githubusercontent.com/8909148/66073512-00f5fc80-e50c-11e9-8d58-7cb67f104c1e.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.