### PR TITLE
[Code + UnitTest] - Fix for broadcast receiver race condition issue

### DIFF
--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -116,7 +116,7 @@ public class PlacesActivity extends Activity {
 		Context context = App.getAppContext();
 
 		if (context == null) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to request permission, context is null");
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to request permission, App context is null");
 			return;
 		}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -23,11 +23,11 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.LocalBroadcastManager;
 import android.view.WindowManager;
 import com.google.android.gms.location.LocationSettingsStates;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import static com.google.android.gms.common.ConnectionResult.RESOLUTION_REQUIRED;
@@ -240,10 +240,7 @@ public class PlacesActivity extends Activity {
 	 * Permission handler method called when user has given permission to access fine location.
 	 */
 	private void onPermissionGranted() {
-	    Intent intent = new Intent();
-	    intent.setAction(PlacesMonitorConstants.INTENT_ACTION_PERMISSION_GRANTED);
-		LocalBroadcastManager manager = LocalBroadcastManager.getInstance(getApplicationContext());
-		manager.sendBroadcast(intent);
+		dispatchPermissionChangeOSEvent(PlacesMonitorConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_GRANTED);
 		finish();
 	}
 
@@ -251,9 +248,7 @@ public class PlacesActivity extends Activity {
 	 * Permission handler method called when user has denied permission to access fine location.
 	 */
 	private void onPermissionDenied() {
-        Intent intent = new Intent(PlacesMonitorConstants.INTENT_ACTION_PERMISSION_DENIED);
-        LocalBroadcastManager manager = LocalBroadcastManager.getInstance(getApplicationContext());
-        manager.sendBroadcast(intent);
+		dispatchPermissionChangeOSEvent(PlacesMonitorConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_DENIED);
 		finish();
 	}
 
@@ -278,6 +273,23 @@ public class PlacesActivity extends Activity {
 		ActivityCompat.requestPermissions(this,
 				  						  getPermissionArray(locationPermission),
 										  PlacesMonitorConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE);
+	}
+
+	/**
+	 * Dispatch an OS event to eventHub, indicating the change in location permission
+	 *
+	 * @param status A {@link String} value representing the status of the changed permission.
+	 */
+	private void dispatchPermissionChangeOSEvent(final String status) {
+		// create eventData
+		HashMap<String,Object> eventData = new HashMap<>();
+		eventData.put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_PERMISSION_CHANGE);
+		eventData.put(PlacesMonitorConstants.EventDataKey.LOCATION_PERMISSION_STATUS, status);
+
+		// dispatch OS event
+		Event event = new Event.Builder(PlacesMonitorConstants.EVENTNAME_OS_PERMISSION_CHANGE,PlacesMonitorConstants.EventType.OS, PlacesMonitorConstants.EventSource.RESPONSE_CONTENT).
+				setEventData(eventData).build();
+		MobileCore.dispatchEvent(event, null);
 	}
 
 }

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
@@ -44,8 +44,8 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 	 *  No action is taken if actionName of the intent is not equal to {@link #ACTION_GEOFENCE_UPDATE}.
 	 *  No action is taken if {@link GeofencingEvent} has error or if no geofences associated with the event.
 	 *
-	 * @param context the application's {@link Context}
-	 * @param intent the broadcasted geofence event message wrapped in an intent
+	 * @param context 	the application's {@link Context}
+	 * @param intent 	the broadcasted geofence event message wrapped in an intent
 	 */
 	@Override
 	public void onReceive(Context context, Intent intent) {
@@ -98,6 +98,13 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 	}
 
 
+	/**
+	 * Creates and dispatches {@link PlacesMonitorConstants.EventType#OS} {@link PlacesMonitorConstants.EventSource#RESPONSE_CONTENT} event with
+	 * obtained list of geofenceIDs and transitionType to the eventHub.
+	 *
+	 * @param geofenceIDs		A {@link List} of geofenceIDs
+	 * @param transitionType	An {@code int} representing the type of geofence transition
+	 */
 	private void dispatchOSGeofenceTriggerEvent(final List<String> geofenceIDs, final int transitionType) {
 		// create eventData
 		HashMap<String,Object> eventData = new HashMap<>();

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
@@ -18,7 +18,13 @@ package com.adobe.marketing.mobile;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.LocalBroadcastManager;
+
+import com.google.android.gms.location.Geofence;
+import com.google.android.gms.location.GeofencingEvent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Broadcast receiver for the geofence updates.
@@ -32,9 +38,11 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 	/**
 	 * This method is called when the {@link PlacesGeofenceBroadcastReceiver} is receiving an intent with geofence event.
 	 * <p>
-	 *  Broadcasts the obtained intent to the internal receiver created and listened by {@link PlacesMonitorInternal}.
-	 *  No action is taken if received intent or context is null.
+	 *  Dispatches an event with EventType {@link PlacesMonitorConstants.EventType#OS} and EventSource {@link PlacesMonitorConstants.EventSource#RESPONSE_CONTENT}
+	 *  with the obtained geofence triggers.
+	 *  No action is taken if received intent is null.
 	 *  No action is taken if actionName of the intent is not equal to {@link #ACTION_GEOFENCE_UPDATE}.
+	 *  No action is taken if {@link GeofencingEvent} has error or if no geofences associated with the event.
 	 *
 	 * @param context the application's {@link Context}
 	 * @param intent the broadcasted geofence event message wrapped in an intent
@@ -55,18 +63,53 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 			return;
 		}
 
-		if (context == null) {
+		GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
+
+		if (geofencingEvent.hasError()) {
 			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"PlacesGeofenceBroadcastReceiver : Unable to process the geofence trigger, context is null");
+					"Cannot process the geofence trigger, Geofencing event has error. Ignoring region event.");
 			return;
 		}
 
-		// change the action name of the intent to broadcast it to the internal class
-		intent.setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
-		LocalBroadcastManager manager = LocalBroadcastManager.getInstance(context);
-		Log.debug(PlacesMonitorConstants.LOG_TAG,
-				  "PlacesGeofenceBroadcastReceiver : Broadcasting the obtained geofence trigger to the PlacesMonitorInternal class");
-		manager.sendBroadcast(intent);
+		List<Geofence> obtainedGeofences = geofencingEvent.getTriggeringGeofences();
+
+		if (obtainedGeofences == null || obtainedGeofences.isEmpty()) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG,
+					"Cannot process the geofence trigger, null or empty geofence obtained from the geofence trigger");
+
+			return;
+		}
+
+
+		// create a list of geofence ID's
+		List<String> geofenceIDs = new ArrayList<String>();
+
+		for (Geofence geofence : obtainedGeofences) {
+			geofenceIDs.add(geofence.getRequestId());
+		}
+
+		dispatchOSGeofenceTriggerEvent(geofenceIDs, geofencingEvent.getGeofenceTransition());
 	}
+
+
+	private void dispatchOSGeofenceTriggerEvent(final List<String> geofenceIDs, final int transitionType) {
+		// create eventData
+		HashMap<String,Object> eventData = new HashMap<>();
+
+		eventData.put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_GEOFENCE_TRIGGER);
+		eventData.put(PlacesMonitorConstants.EventDataKey.GEOFENCE_IDS, geofenceIDs);
+		eventData.put(PlacesMonitorConstants.EventDataKey.GEOFENCE_TRANSITION_TYPE, transitionType);
+
+		// dispatch OS event
+		Event event = new Event.Builder(PlacesMonitorConstants.EVENTNAME_OS_GEOFENCE_TRIGGER,PlacesMonitorConstants.EventType.OS, PlacesMonitorConstants.EventSource.RESPONSE_CONTENT).
+				setEventData(eventData).build();
+		MobileCore.dispatchEvent(event, null);
+
+	}
+
+
+
+
+
 
 }

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
@@ -67,7 +67,7 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 
 		if (geofencingEvent.hasError()) {
 			Log.warning(PlacesMonitorConstants.LOG_TAG,
-					"Cannot process the geofence trigger, Geofencing event has error. Ignoring region event.");
+					"PlacesGeofenceBroadcastReceiver : Cannot process the geofence trigger, Geofencing event has error. Ignoring region event.");
 			return;
 		}
 
@@ -75,7 +75,7 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 
 		if (obtainedGeofences == null || obtainedGeofences.isEmpty()) {
 			Log.warning(PlacesMonitorConstants.LOG_TAG,
-					"Cannot process the geofence trigger, null or empty geofence obtained from the geofence trigger");
+					"PlacesGeofenceBroadcastReceiver : Cannot process the geofence trigger, null or empty geofence obtained from the geofence trigger");
 
 			return;
 		}
@@ -103,8 +103,14 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 		// dispatch OS event
 		Event event = new Event.Builder(PlacesMonitorConstants.EVENTNAME_OS_GEOFENCE_TRIGGER,PlacesMonitorConstants.EventType.OS, PlacesMonitorConstants.EventSource.RESPONSE_CONTENT).
 				setEventData(eventData).build();
-		MobileCore.dispatchEvent(event, null);
-
+		if (MobileCore.dispatchEvent(event, null)) {
+			Log.debug(PlacesMonitorConstants.LOG_TAG,
+					"PlacesGeofenceBroadcastReceiver : Successfully dispatched OS Response event with geofence transitions");
+		}
+		else {
+			Log.warning(PlacesMonitorConstants.LOG_TAG,
+					"PlacesGeofenceBroadcastReceiver : Unable to dispatch the OS Response event with geofence transitions");
+		}
 	}
 
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiver.java
@@ -65,6 +65,12 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 
 		GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
 
+		if (geofencingEvent == null) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG,
+					"PlacesGeofenceBroadcastReceiver : Unable to process the geofence trigger, GeofencingEvent is null");
+			return;
+		}
+
 		if (geofencingEvent.hasError()) {
 			Log.warning(PlacesMonitorConstants.LOG_TAG,
 					"PlacesGeofenceBroadcastReceiver : Cannot process the geofence trigger, Geofencing event has error. Ignoring region event.");
@@ -108,14 +114,7 @@ public class PlacesGeofenceBroadcastReceiver extends BroadcastReceiver {
 					"PlacesGeofenceBroadcastReceiver : Successfully dispatched OS Response event with geofence transitions");
 		}
 		else {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-					"PlacesGeofenceBroadcastReceiver : Unable to dispatch the OS Response event with geofence transitions");
+			Log.warning(PlacesMonitorConstants.LOG_TAG,String.format("PlacesGeofenceBroadcastReceiver : Unable to dispatch the OS Response event with geofence transitions %s", event.getEventData()));
 		}
 	}
-
-
-
-
-
-
 }

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
@@ -46,6 +46,9 @@ import java.util.Set;
  */
 class PlacesGeofenceManager {
 
+	private final double INCONSEQUENTIAL_LATITUDE = 0.0;
+	private final double INCONSEQUENTIAL_LONGITUDE =  0.0;
+	private final float INCONSEQUENTIAL_RADIUS = 100.0f;
 	private final String FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
 	private PendingIntent geofencePendingIntent;
 	private Set<String> userWithinGeofences;
@@ -191,54 +194,48 @@ class PlacesGeofenceManager {
 	 * Handler for processing the received geofence event.
 	 *
 	 * <p>
-	 * This method is called by the internal BroadcastReceiver on receiving an intent with {@link GeofencingEvent}.
-	 * Calls the {@link PlacesExtension} to process the obtained {@link Geofence} triggers.
+	 * This method will be called when the OS event for Geofence transitions is received.
+	 * This method curates the list of geofence transitions received to prevent duplicate entry/exits and then
+	 * calls the {@link PlacesExtension} to process the obtained {@link Geofence} triggers.
 	 *
-	 * No action is performed if the intents actionName is not same as {@link PlacesMonitorConstants#INTERNAL_INTENT_ACTION_GEOFENCE}.
-	 * No action is performed if the received {@code GeofencingEvent} has error.
-	 * No action is performed if the list of obtained {@code Geofences} is empty.
-	 *
-	 * @param intent the broadcasted geofence event message wrapped in an intent
+	 * @param eventData the {@link EventData} from the OS Event containing geofence transition information.
 	 * @see Places#processGeofence(Geofence, int)
 	 */
-	void onGeofenceReceived(final Intent intent) {
-		if (intent == null) {
-			Log.error(PlacesMonitorConstants.LOG_TAG,
-					  "Cannot process the geofence trigger, The received intent from the geofence broadcast receiver is null.");
+	void onGeofenceTriggerReceived(final EventData eventData) {
+
+		List<String> geofenceIDs;
+		int transitionType;
+		try {
+
+			geofenceIDs = eventData.getStringList(PlacesMonitorConstants.EventDataKey.GEOFENCE_IDS);
+			transitionType = eventData.getInteger(PlacesMonitorConstants.EventDataKey.GEOFENCE_TRANSITION_TYPE);
+		} catch (VariantException exp) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "Exception occured while reading the geofenceIds from the OS event. " + exp.getMessage() + "Ignoring the OS event.");
 			return;
 		}
 
-		final String action = intent.getAction();
-
-		if (!PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE.equals(action)) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"Cannot process the geofence trigger, Invalid action type received from geofence broadcast receiver.");
-			return;
-		}
-
-		GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
-
-		if (geofencingEvent.hasError()) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"Cannot process the geofence trigger, Geofencing event has error. Ignoring region event.");
-			return;
-		}
-
-		List<Geofence> obtainedGeofences = geofencingEvent.getTriggeringGeofences();
-
-		if (obtainedGeofences == null || obtainedGeofences.isEmpty()) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"Cannot process the geofence trigger, null or empty geofence obtained from the geofence trigger");
-
+		if(geofenceIDs == null || geofenceIDs.size() <=0) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "no geofenceId's are obtained from OS geofence event. Ignoring the OS event.");
 			return;
 		}
 
 		// curate the obtained geofence list
-		List<Geofence> curatedGeofences  = getCuratedGeofencesList(obtainedGeofences, geofencingEvent.getGeofenceTransition());
+		List<String> curatedGeofences  = getCuratedGeofencesList(geofenceIDs, transitionType);
 
 		// dispatch a region event for the places list
-		for (Geofence geofence : curatedGeofences) {
-			Places.processGeofence(geofence, geofencingEvent.getGeofenceTransition());
+		for (String geofenceID : curatedGeofences) {
+			// Creating a geofence object.
+			// To successfully create a geofence object, setting of latitude, longitude, radius, transition type and expiry duration are required.
+			// Note : This geofence object is created with inconsequential latitude, longitude and radius.
+			// Places API method processGeofence only reads the geofenceId of the triggered fences. Moreover latitude, longitude and radius cannot be extracted
+			// from the geofence object. Unless its passed to android for monitoring.
+			Geofence geofence = new Geofence.Builder()
+					.setRequestId(geofenceID)
+					.setExpirationDuration(Geofence.NEVER_EXPIRE)
+					.setTransitionTypes(transitionType)
+					.setCircularRegion(INCONSEQUENTIAL_LATITUDE,INCONSEQUENTIAL_LONGITUDE,INCONSEQUENTIAL_RADIUS)
+					.build();
+			Places.processGeofence(geofence, transitionType);
 		}
 	}
 
@@ -247,37 +244,40 @@ class PlacesGeofenceManager {
 	// ================================================================================================================================
 
 	/**
-	 * Compares with the existing in-memory {@code #userWithinGeofences} list and get the to be processed {@link Geofence} list.
+	 * Compares with the existing in-memory {@code #userWithinGeofences} list, ignores the duplicate entry event,
+	 * updates the in-memory {@code #userWithinGeofences} variable with the obtained geofences and finally returns the curated list
+	 * of GeofenceIDs that needs to be processed
 	 *
-	 * @param obtainedGeofences A {@link List} of {@code Geofence} obtained from the {@link GeofencingEvent}
+	 *
+	 * @param obtainedGeofenceIds A {@link List} of {@code String} representing geofenceIDs obtained from the OS event
 	 * @param transitionType {@code int} representing the transition type of the provided list of geofences
 	 *
 	 * @return the curated list of {@code Geofence}'s that needs to be processed by {@link Places} extension
 	 */
-	List<Geofence> getCuratedGeofencesList(final List<Geofence> obtainedGeofences, final int transitionType) {
-		List<Geofence> curatedGeofenceList = new ArrayList<Geofence>();
+	List<String> getCuratedGeofencesList(final List<String> obtainedGeofenceIds, final int transitionType) {
+		List<String> curatedGeofenceList = new ArrayList<String>();
 
 		// if entry event, add geofence to the userWithinGeofence
 		if (transitionType == Geofence.GEOFENCE_TRANSITION_ENTER) {
-			for (Geofence geofence : obtainedGeofences) {
-				if (!userWithinGeofences.contains(geofence.getRequestId())) {
-					curatedGeofenceList.add(geofence);
-					userWithinGeofences.add(geofence.getRequestId());
+			for (String geofenceID : obtainedGeofenceIds) {
+				if (!userWithinGeofences.contains(geofenceID)) {
+					curatedGeofenceList.add(geofenceID);
+					userWithinGeofences.add(geofenceID);
 				} else {
 					Log.debug(PlacesMonitorConstants.LOG_TAG,
-							  "Ignoring to process the entry of geofence" + geofence.getRequestId() + ".Because an entry was already recorded");
+							  "Ignoring to process the entry of geofence" + geofenceID + ".Because an entry was already recorded");
 				}
 			}
 		}
 
 		// if exit event, remove from the userWithinGeofence
 		else if (transitionType == Geofence.GEOFENCE_TRANSITION_EXIT) {
-			for (Geofence geofence : obtainedGeofences) {
-				if (userWithinGeofences.contains(geofence.getRequestId())) {
-					userWithinGeofences.remove(geofence.getRequestId());
+			for (String geofenceID : obtainedGeofenceIds) {
+				if (userWithinGeofences.contains(geofenceID)) {
+					userWithinGeofences.remove(geofenceID);
 				}
 
-				curatedGeofenceList.add(geofence);
+				curatedGeofenceList.add(geofenceID);
 			}
 		}
 
@@ -439,7 +439,7 @@ class PlacesGeofenceManager {
 
 		if (!checkPermissions()) {
 			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"Unable to monitor geofences, App permission to use FINE_LOCATION is not granted.");
+						"Unable to register new geofences, App permission to use FINE_LOCATION is not granted.");
 			return;
 		}
 
@@ -447,7 +447,7 @@ class PlacesGeofenceManager {
 
 		if (geofenceIntent == null) {
 			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"Unable to stop monitoring geofences, Places Geofence Broadcast Receiver was never initialized");
+						"Unable to register new geofences, Places Geofence Broadcast Receiver was never initialized");
 			return;
 		}
 
@@ -468,7 +468,7 @@ class PlacesGeofenceManager {
 			.setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 								Geofence.GEOFENCE_TRANSITION_EXIT)
 			.build();
-			Log.debug(PlacesMonitorConstants.LOG_TAG, "Attempting to Monitor location with id " + poi.getIdentifier() +
+			Log.debug(PlacesMonitorConstants.LOG_TAG, "Attempting to Monitor POI with id " + poi.getIdentifier() +
 					  " name " + poi.getName() +
 					  " latitude " + poi.getLatitude() +
 					  " longitude " + poi.getLongitude());

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
@@ -25,7 +25,6 @@ import android.support.v4.app.ActivityCompat;
 
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingClient;
-import com.google.android.gms.location.GeofencingEvent;
 import com.google.android.gms.location.GeofencingRequest;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -211,12 +210,12 @@ class PlacesGeofenceManager {
 			geofenceIDs = eventData.getStringList(PlacesMonitorConstants.EventDataKey.GEOFENCE_IDS);
 			transitionType = eventData.getInteger(PlacesMonitorConstants.EventDataKey.GEOFENCE_TRANSITION_TYPE);
 		} catch (VariantException exp) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "Exception occured while reading the geofenceIds from the OS event. " + exp.getMessage() + "Ignoring the OS event.");
+			Log.warning(PlacesMonitorConstants.LOG_TAG, String.format("Exception occurred while reading the geofenceIds from the OS event, ignoring the OS event. Exception message - ", exp.getMessage()));
 			return;
 		}
 
-		if(geofenceIDs == null || geofenceIDs.size() <=0) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "no geofenceId's are obtained from OS geofence event. Ignoring the OS event.");
+		if(geofenceIDs == null || geofenceIDs.isEmpty()) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "No geofenceId's are obtained from OS geofence event. Ignoring the OS event.");
 			return;
 		}
 
@@ -228,8 +227,8 @@ class PlacesGeofenceManager {
 			// Creating a geofence object.
 			// To successfully create a geofence object, setting of latitude, longitude, radius, transition type and expiry duration are required.
 			// Note : This geofence object is created with inconsequential latitude, longitude and radius.
-			// Places API method processGeofence only reads the geofenceId of the triggered fences. Moreover latitude, longitude and radius cannot be extracted
-			// from the geofence object. Unless its passed to android for monitoring.
+			// Places API method processGeofence only reads the geofenceId of the triggered fences. Other data elements are not used by the Places.processGeofence API.
+			// Moreover latitude, longitude and radius cannot be extracted from the geofence object. Unless its passed to android for monitoring.
 			Geofence geofence = new Geofence.Builder()
 					.setRequestId(geofenceID)
 					.setExpirationDuration(Geofence.NEVER_EXPIRE)
@@ -265,8 +264,7 @@ class PlacesGeofenceManager {
 					curatedGeofenceList.add(geofenceID);
 					userWithinGeofences.add(geofenceID);
 				} else {
-					Log.debug(PlacesMonitorConstants.LOG_TAG,
-							  "Ignoring to process the entry of geofence" + geofenceID + ".Because an entry was already recorded");
+					Log.debug(PlacesMonitorConstants.LOG_TAG, String.format("Ignoring to process the entry of geofenceId %s. Because an entry was already recorded",geofenceID));
 				}
 			}
 		}
@@ -359,7 +357,7 @@ class PlacesGeofenceManager {
 		AdobeCallback<String> onFailiure = new AdobeCallback<String>() {
 			@Override
 			public void call(String message) {
-				Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to unregister old nearByPois," + message);
+				Log.warning(PlacesMonitorConstants.LOG_TAG, String.format("Unable to unregister old nearByPois. Error message %s.", message));
 				registerPOIs(nearByPOIs);
 			}
 		};
@@ -469,10 +467,7 @@ class PlacesGeofenceManager {
 			.setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 								Geofence.GEOFENCE_TRANSITION_EXIT)
 			.build();
-			Log.debug(PlacesMonitorConstants.LOG_TAG, "Attempting to Monitor POI with id " + poi.getIdentifier() +
-					  " name " + poi.getName() +
-					  " latitude " + poi.getLatitude() +
-					  " longitude " + poi.getLongitude());
+			Log.debug(PlacesMonitorConstants.LOG_TAG, String.format("Attempting to Monitor POI with id %s name %s latitude %s longitude %s", poi.getIdentifier(), poi.getName(), poi.getLatitude(), poi.getLongitude()));
 			geofences.add(fence);
 		}
 
@@ -495,7 +490,7 @@ class PlacesGeofenceManager {
 			task.addOnSuccessListener(new OnSuccessListener<Void>() {
 				@Override
 				public void onSuccess(Void aVoid) {
-					Log.debug(PlacesMonitorConstants.LOG_TAG, "Successfully added " + geofences.size() + " fences for monitoring");
+					Log.debug(PlacesMonitorConstants.LOG_TAG, String.format("Successfully added %d fences for monitoring",geofences.size()));
 				}
 			});
 			task.addOnFailureListener(new OnFailureListener() {

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
@@ -145,7 +145,7 @@ class PlacesGeofenceManager {
 				continue;
 			}
 
-			// if the user is not withIn the poi and userWithinGeofences list contains the poi, remove it
+			// if the user is not within the poi and userWithinGeofences list contains the poi, remove it
 			if (!poi.containsUser() && userWithinGeofences.contains(poi.getIdentifier())) {
 				userWithinGeofences.remove(poi.getIdentifier());
 			}
@@ -194,11 +194,12 @@ class PlacesGeofenceManager {
 	 * Handler for processing the received geofence event.
 	 *
 	 * <p>
+	 * Make sure this method is called with non-null eventData.
 	 * This method will be called when the OS event for Geofence transitions is received.
 	 * This method curates the list of geofence transitions received to prevent duplicate entry/exits and then
 	 * calls the {@link PlacesExtension} to process the obtained {@link Geofence} triggers.
 	 *
-	 * @param eventData the {@link EventData} from the OS Event containing geofence transition information.
+	 * @param eventData the {@link EventData} from the OS Event containing geofence transition information
 	 * @see Places#processGeofence(Geofence, int)
 	 */
 	void onGeofenceTriggerReceived(final EventData eventData) {
@@ -246,7 +247,7 @@ class PlacesGeofenceManager {
 	/**
 	 * Compares with the existing in-memory {@code #userWithinGeofences} list, ignores the duplicate entry event,
 	 * updates the in-memory {@code #userWithinGeofences} variable with the obtained geofences and finally returns the curated list
-	 * of GeofenceIDs that needs to be processed
+	 * of GeofenceIDs that needs to be processed.
 	 *
 	 *
 	 * @param obtainedGeofenceIds A {@link List} of {@code String} representing geofenceIDs obtained from the OS event

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesGeofenceManager.java
@@ -63,7 +63,7 @@ class PlacesGeofenceManager {
 	 * This method is called by {@link PlacesMonitorInternal} when new set of POIs are available for monitoring.
 	 * No action will be performed if the {@link GeofencingClient} required for the monitoring the POIs is null.
 	 *
-	 * @param nearByPOIs A {@link List} of n nearBy {@link PlacesPOI} objects
+	 * @param nearByPOIs 	A {@link List} of n nearBy {@link PlacesPOI} objects
 	 * @see #getGeofencingClient()
 	 */
 	void startMonitoringFences(List<PlacesPOI> nearByPOIs) {
@@ -453,13 +453,13 @@ class PlacesGeofenceManager {
 
 		for (PlacesPOI poi : nearByPOIs) {
 
-			/**
-			 * If a geofence was previously registered, reading them will just replace the old one, which
-			 * in our case is a no-op. We therefore don't really need to keep track which geofence was
-			 * registered before, which can go out of sync anyway with the OS. Furthermore, android
-			 * does not provide any API to query which geofences are currenty monitored, so it's safer
-			 * to re-register previously registered geofences.
-			 */
+
+			 // If a geofence was previously registered, reading them will just replace the old one, which
+			 // in our case is a no-op. We therefore don't really need to keep track which geofence was
+			 // registered before, which can go out of sync anyway with the OS. Furthermore, android
+			 // does not provide any API to query which geofences are currently monitored, so it's safer
+			 // to re-register previously registered geofences.
+
 			final Geofence fence = new Geofence.Builder()
 			.setRequestId(poi.getIdentifier())
 			.setCircularRegion(poi.getLatitude(), poi.getLongitude(), poi.getRadius())
@@ -478,10 +478,11 @@ class PlacesGeofenceManager {
 
 		GeofencingRequest.Builder builder = new GeofencingRequest.Builder();
 
-		/*	by default initial trigger is set to INITIAL_TRIGGER_ENTER | INITIAL_TRIGGER_DWELL
-		*   This is not what we want since it will result in duplicate triggers if we are already
-		 *   inside POI(s).
-		* */
+
+		 // By default initial trigger is set to INITIAL_TRIGGER_ENTER | INITIAL_TRIGGER_DWELL
+		 // This is not what we want since it will result in duplicate triggers if we are already
+		 // inside POI(s).
+
 		builder.setInitialTrigger(0);
 		builder.addGeofences(geofences);
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationBroadcastReceiver.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationBroadcastReceiver.java
@@ -18,7 +18,10 @@ package com.adobe.marketing.mobile;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.LocalBroadcastManager;
+import android.location.Location;
+import com.google.android.gms.location.LocationResult;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Broadcast receiver for the location updates.
@@ -30,11 +33,14 @@ public class PlacesLocationBroadcastReceiver extends BroadcastReceiver {
 		"com.adobe.marketing.mobile.PlacesLocationBroadcastReceiver.locationUpdates";
 
 	/**
-	 * This method is called when the BroadcastReceiver is receiving an intent broadcast with current location.
+	 * This method is called when the {@link PlacesLocationBroadcastReceiver} is receiving an intent broadcast with current location.
 	 * <p>
-	 *  Broadcasts the obtained intent to the internal receiver created and listened by {@link PlacesMonitorInternal}
-	 *  No action is taken if the passed intent or context is null.
-	 *  No action is taken if the actionName of the intent is not same as {@link #ACTION_LOCATION_UPDATE}
+	 *  Dispatches an event with EventType {@link PlacesMonitorConstants.EventType#OS} and EventSource {@link PlacesMonitorConstants.EventSource#RESPONSE_CONTENT}
+	 * 	with the obtained location.
+	 *  No action is taken if the passed intent is null.
+	 *  No action is taken if the actionName of the intent is not same as {@link #ACTION_LOCATION_UPDATE}.
+	 *  No action is performed if the received {@code LocationResult} is null.
+	 *  No action is performed if the location array or the location is null.
 	 *
 	 * @param context the application's {@link Context}
 	 * @param intent the broadcasted location message wrapped in an intent
@@ -55,18 +61,50 @@ public class PlacesLocationBroadcastReceiver extends BroadcastReceiver {
 			return;
 		}
 
-		if (context == null) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"PlacesLocationBroadcastReceiver : Unable to process the location, context is null");
+
+		LocationResult result = LocationResult.extractResult(intent);
+		if (result == null) {
 			return;
 		}
 
-		// change the action name of the intent to broadcast it to the internal class
-		intent.setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_LOCATION);
-		LocalBroadcastManager manager = LocalBroadcastManager.getInstance(context);
-		Log.debug(PlacesMonitorConstants.LOG_TAG,
-				  "PlacesLocationBroadcastReceiver : Broadcasting the obtained location to the PlacesMonitorInternal class");
-		manager.sendBroadcast(intent);
+		List<Location> locations = result.getLocations();
+
+		if (locations == null || locations.isEmpty()) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationBroadcastReceiver : Cannot process the location update, Received location array is null");
+			return;
+		}
+
+		Location location = locations.get(0);
+
+		if (location == null) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationBroadcastReceiver : Cannot process the location update, Received location is null");
+			return;
+		}
+
+		String locationLog = "PlacesLocationBroadcastReceiver : A new location received with accuracy: " + location.getAccuracy() + " lat: " + location.getLatitude() +
+				" lon: " + location.getLongitude();
+		Log.debug(PlacesMonitorConstants.LOG_TAG, locationLog);
+		dispatchOSLocationUpdateEvent(location.getLatitude(), location.getLongitude());
+	}
+
+
+	private void dispatchOSLocationUpdateEvent(final double latitude, final double longitude) {
+		HashMap<String,Object> eventData = new HashMap<>();
+		eventData.put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_UPDATE);
+		eventData.put(PlacesMonitorConstants.EventDataKey.LATITUDE, latitude);
+		eventData.put(PlacesMonitorConstants.EventDataKey.LONGITUDE, longitude);
+
+		Event event = new Event.Builder(PlacesMonitorConstants.EVENTNAME_OS_LOCATION_UPDATE,PlacesMonitorConstants.EventType.OS, PlacesMonitorConstants.EventSource.RESPONSE_CONTENT).
+				setEventData(eventData).build();
+		if (MobileCore.dispatchEvent(event, null)) {
+			Log.debug(PlacesMonitorConstants.LOG_TAG,
+					"PlacesLocationBroadcastReceiver : Successfully dispatched OS Response event with new location");
+		}
+		else {
+			Log.warning(PlacesMonitorConstants.LOG_TAG,
+					"PlacesLocationBroadcastReceiver : Unable to dispatch the OS Response event with new location");
+		}
+
 	}
 
 }

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationBroadcastReceiver.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationBroadcastReceiver.java
@@ -42,8 +42,8 @@ public class PlacesLocationBroadcastReceiver extends BroadcastReceiver {
 	 *  No action is performed if the received {@code LocationResult} is null.
 	 *  No action is performed if the location array or the location is null.
 	 *
-	 * @param context the application's {@link Context}
-	 * @param intent the broadcasted location message wrapped in an intent
+	 * @param context 	the application's {@link Context}
+	 * @param intent 	the broadcasted location message wrapped in an intent
 	 */
 	@Override
 	public void onReceive(Context context, Intent intent) {
@@ -88,6 +88,13 @@ public class PlacesLocationBroadcastReceiver extends BroadcastReceiver {
 	}
 
 
+	/**
+	 * Creates and dispatches {@link PlacesMonitorConstants.EventType#OS} {@link PlacesMonitorConstants.EventSource#RESPONSE_CONTENT} event with
+	 * obtained latitude and longitude to the eventHub.
+	 *
+	 * @param latitude 		{@code double} indicating latitude value
+	 * @param longitude		{@code double} indicating longitude value
+	 */
 	private void dispatchOSLocationUpdateEvent(final double latitude, final double longitude) {
 		HashMap<String,Object> eventData = new HashMap<>();
 		eventData.put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_UPDATE);
@@ -101,8 +108,7 @@ public class PlacesLocationBroadcastReceiver extends BroadcastReceiver {
 					"PlacesLocationBroadcastReceiver : Successfully dispatched OS Response event with new location");
 		}
 		else {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-					"PlacesLocationBroadcastReceiver : Unable to dispatch the OS Response event with new location");
+			Log.warning(PlacesMonitorConstants.LOG_TAG,String.format("PlacesLocationBroadcastReceiver : Unable to dispatch the OS Response event with new location %s", eventData));
 		}
 
 	}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
@@ -272,13 +272,13 @@ class PlacesLocationManager {
 			longitude = eventData.getDouble(PlacesMonitorConstants.EventDataKey.LONGITUDE);
 		}
 		catch (VariantException exception) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationManager : Exception occurred while extracting latitude/longitude from the OS event. Ignoring location update event." + exception.getMessage());
+			Log.warning(PlacesMonitorConstants.LOG_TAG, String.format("PlacesLocationManager : Exception occurred while extracting latitude/longitude from the OS event. Ignoring location update event. Error message - %s", exception.getMessage()));
 			return;
 		}
 
 
 		if(!isValidLat(latitude) || !isValidLon(longitude)){
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationManager : Invalid Latitude: ("+latitude+") or Longitude (" + longitude + ") obtained from the OS event. Ignoring location update event.");
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationManager : Invalid Latitude: (" +latitude+ ") or Longitude (" + longitude + ") obtained from the OS event. Ignoring location update event.");
 			return;
 		}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
@@ -279,6 +279,7 @@ class PlacesLocationManager {
 
 		if(!isValidLat(latitude) || !isValidLon(longitude)){
 			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationManager : Invalid Latitude: ("+latitude+") or Longitude (" + longitude + ") obtained from the OS event. Ignoring location update event.");
+			return;
 		}
 
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesLocationManager.java
@@ -28,7 +28,6 @@ import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.ResolvableApiException;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationRequest;
-import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.location.LocationSettingsRequest;
 import com.google.android.gms.location.LocationSettingsResponse;
@@ -39,13 +38,17 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 
-import java.util.List;
-
 
 /**
  * Class to manage location updates from Android OS
  */
 class PlacesLocationManager {
+
+	// Latitude/Longitude constants
+	private static final double MAX_LAT		= 90d;
+	private static final double MIN_LAT		= -90d;
+	private static final double MAX_LON		= 180d;
+	private static final double MIN_LON		= -180d;
 
 	// permission constants
 	private FusedLocationProviderClient fusedLocationClient;
@@ -254,58 +257,34 @@ class PlacesLocationManager {
 
 	/**
 	 * Handler for processing the received location event.
-	 *
 	 * <p>
-	 * This method is called by the internal {@link android.content.BroadcastReceiver} on receiving an intent with {@link Location}.
-	 * Calls the {@link PlacesExtension} to get the closest POIs around the given location.
+	 * This method will be called when the OS event on location update is received.
+	 * This method attempts to fetch and monitor 20 near by POIs around the given location.
 	 *
-	 * No action is performed if the intents action is not same as {@link PlacesMonitorConstants#INTERNAL_INTENT_ACTION_LOCATION}.
-	 * No action is performed if the received {@code LocationResult} is null.
-	 * No action is performed if the location array or the location is null.
-	 *
-	 * @param intent broadcasted geofence event message wrapped in an intent
+	 * @param eventData {@link EventData} from the location update OS event.
 	 * @see Places#getNearbyPointsOfInterest(Location, int, AdobeCallback)
 	 */
-	void onLocationReceived(final Intent intent) {
-
-		if (intent == null) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"Cannot process the location update, The received intent from the location broadcast receiver  is null");
+	void onLocationReceived(final EventData eventData) {
+		double latitude;
+		double longitude;
+		try {
+			latitude = eventData.getDouble(PlacesMonitorConstants.EventDataKey.LATITUDE);
+			longitude = eventData.getDouble(PlacesMonitorConstants.EventDataKey.LONGITUDE);
+		}
+		catch (VariantException exception) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationManager : Exception occurred while extracting latitude/longitude from the OS event. Ignoring location update event." + exception.getMessage());
 			return;
 		}
 
-		final String action = intent.getAction();
 
-		if (!PlacesMonitorConstants.INTERNAL_INTENT_ACTION_LOCATION.equals(action)) {
-			Log.trace(PlacesMonitorConstants.LOG_TAG,
-					  "Cannot process the location update, Invalid action type received from location broadcast receiver");
-			return;
+		if(!isValidLat(latitude) || !isValidLon(longitude)){
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesLocationManager : Invalid Latitude: ("+latitude+") or Longitude (" + longitude + ") obtained from the OS event. Ignoring location update event.");
 		}
 
-		LocationResult result = LocationResult.extractResult(intent);
 
-		if (result == null) {
-			return;
-		}
-
-		List<Location> locations = result.getLocations();
-
-		if (locations == null || locations.isEmpty()) {
-			Log.trace(PlacesMonitorConstants.LOG_TAG, "Cannot process the location update, Received location array is null");
-			return;
-		}
-
-		Location location = locations.get(0);
-
-		if (location == null) {
-			Log.trace(PlacesMonitorConstants.LOG_TAG, "Cannot process the location update, Received location is null");
-			return;
-		}
-
-		String locationLog = "Location Received: Accuracy: " + location.getAccuracy() + " lat: " + location.getLatitude() +
-							 " lon: " +
-							 location.getLongitude();
-		Log.debug(PlacesMonitorConstants.LOG_TAG, locationLog);
+		Location location = new Location("Places Monitor location");
+		location.setLatitude(latitude);
+		location.setLongitude(longitude);
 		placesMonitorInternal.getPOIsForLocation(location);
 	}
 
@@ -522,5 +501,29 @@ class PlacesLocationManager {
 
 		return appContext.getSharedPreferences(PlacesMonitorConstants.SharedPreference.MASTER_KEY, 0);
 	}
+
+
+	/**
+	 * Verifies if the provided latitude is valid.
+	 *
+	 * @param latitude the latitude
+	 * @return true if latitude is in the range [-90,90]
+	 */
+	private boolean isValidLat(final double latitude) {
+		return latitude >= MIN_LAT && latitude <= MAX_LAT;
+	}
+
+
+	/**
+	 * Verifies if the provided longitude is valid.
+	 *
+	 * @param longitude the longitude
+	 * @return true if longitude is in the range [-180,180]
+	 */
+	private boolean isValidLon(final double longitude) {
+		return longitude >= MIN_LON && longitude <= MAX_LON;
+	}
+
+
 
 }

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
@@ -15,6 +15,9 @@
 
 package com.adobe.marketing.mobile;
 
+import android.location.Location;
+import android.location.LocationManager;
+
 public class PlacesMonitor {
 
 	/**
@@ -71,7 +74,7 @@ public class PlacesMonitor {
 	public static void setLocationPermission(final PlacesMonitorLocationPermission placesMonitorLocationPermission) {
 		EventData data = new EventData();
 		String locationPermissionString = placesMonitorLocationPermission == null ? null : placesMonitorLocationPermission.getValue();
-		data.putString(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_LOCATION_PERMISSION, locationPermissionString);
+		data.putString(PlacesMonitorConstants.EventDataKey.LOCATION_PERMISSION, locationPermissionString);
 		dispatchMonitorEvent(PlacesMonitorConstants.EVENTNAME_SET_LOCATION_PERMISSION, data);
 	}
 
@@ -147,7 +150,7 @@ public class PlacesMonitor {
 	 */
 	private static void dispatchStopEvent(final boolean clearData) {
 		EventData data = new EventData();
-		data.putBoolean(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_CLEAR, clearData);
+		data.putBoolean(PlacesMonitorConstants.EventDataKey.CLEAR, clearData);
 		final Event stopEvent = new Event.Builder(PlacesMonitorConstants.EVENTNAME_STOP,
 				PlacesMonitorConstants.EventType.MONITOR,
 				PlacesMonitorConstants.EventSource.REQUEST_CONTENT).setData(data).build();

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitor.java
@@ -15,9 +15,6 @@
 
 package com.adobe.marketing.mobile;
 
-import android.location.Location;
-import android.location.LocationManager;
-
 public class PlacesMonitor {
 
 	/**

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
@@ -29,13 +29,11 @@ final class PlacesMonitorConstants {
 	static final String EVENTNAME_STOP = "stop monitoring";
 	static final String EVENTNAME_UPDATE = "update location now";
 	static final String EVENTNAME_SET_LOCATION_PERMISSION = "set location permission";
+	static final String EVENTNAME_OS_PERMISSION_CHANGE = "OS Permission change";
+	static final String EVENTNAME_OS_GEOFENCE_TRIGGER = "OS Geofence Trigger";
+	static final String EVENTNAME_OS_LOCATION_UPDATE = "OS Location update";
 
 	static final int NEARBY_GEOFENCES_COUNT = 20;
-
-	static final String INTERNAL_INTENT_ACTION_LOCATION = "intentactionlocation";
-	static final String INTERNAL_INTENT_ACTION_GEOFENCE = "intentactiongeofence";
-	static final String INTENT_ACTION_PERMISSION_GRANTED = "permissionreceived";
-	static final String INTENT_ACTION_PERMISSION_DENIED = "permissiondenied";
 
 	static final class Location {
 		static final int REQUEST_INTERVAL = 3600;				// 1 hour
@@ -47,6 +45,7 @@ final class PlacesMonitorConstants {
 	}
 
 	static final class EventSource {
+		static final String RESPONSE_CONTENT = "com.adobe.eventsource.responsecontent";
 		static final String REQUEST_CONTENT = "com.adobe.eventsource.requestcontent";
 		static final String SHARED_STATE = "com.adobe.eventsource.sharedstate";
 
@@ -55,16 +54,35 @@ final class PlacesMonitorConstants {
 		}
 	}
 
-	static final class EventDataKeys {
-		static final String EVENT_DATA_CLEAR	= "clearclientdata";
-		static final String EVENT_DATA_LOCATION_PERMISSION = "locationpermission";
-		private EventDataKeys() {
+	static final class EventDataKey {
+		static final String CLEAR = "clearclientdata";
+		static final String LOCATION_PERMISSION = "locationpermission";
+
+		static final String OS_EVENT_TYPE = "oseventtype";
+		static final String LATITUDE = "latitude";
+		static final String LONGITUDE = "longitude";
+		static final String GEOFENCE_IDS = "geofenceIds";
+		static final String GEOFENCE_TRANSITION_TYPE = "transitiontype";
+		static final String LOCATION_PERMISSION_STATUS = "locationpermissionstatus";
+		private EventDataKey() {
+		}
+	}
+
+
+	static final class EventDataValue {
+		static final String OS_EVENT_TYPE_LOCATION_UPDATE = "locationupdate";
+		static final String OS_EVENT_TYPE_GEOFENCE_TRIGGER = "geofencetrigger";
+		static final String OS_EVENT_TYPE_LOCATION_PERMISSION_CHANGE = "locationpermissionchange";
+		static final String OS_LOCATION_PERMISSION_STATUS_GRANTED = "granted";
+		static final String OS_LOCATION_PERMISSION_STATUS_DENIED = "denied";
+		private EventDataValue() {
 		}
 	}
 
 
 	static final class EventType {
 		static final String HUB = "com.adobe.eventtype.hub";
+		static final String OS = "com.adobe.eventtype.os";
 		static final String MONITOR = "com.adobe.eventtype.placesmonitor";
 
 		private EventType() {

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -15,7 +15,6 @@
 
 package com.adobe.marketing.mobile;
 
-import android.content.Context;
 import android.location.Location;
 
 
@@ -48,7 +47,7 @@ class PlacesMonitorInternal extends Extension {
 	 * 	 *  and EventSource {@link PlacesMonitorConstants.EventSource#RESPONSE_CONTENT}</li>
 	 * </ul>
 	 *
-	 * @param extensionApi {@link ExtensionApi} instance
+	 * @param extensionApi 	{@link ExtensionApi} instance
 	 */
 	protected PlacesMonitorInternal(final ExtensionApi extensionApi) {
 		super(extensionApi);
@@ -61,7 +60,7 @@ class PlacesMonitorInternal extends Extension {
 			@Override
 			public void error(ExtensionError extensionError) {
 				if (extensionError != null) {
-					Log.warning("PlacesMonitorInternal : There was an error registering PlacesMonitorListenerHubSharedState for Event Hub shared state events: %s",
+					Log.error("PlacesMonitorInternal : There was an error registering PlacesMonitorListenerHubSharedState for Event Hub shared state events: %s",
 								extensionError.getErrorName());
 				}
 			}
@@ -75,7 +74,7 @@ class PlacesMonitorInternal extends Extension {
 			@Override
 			public void error(ExtensionError extensionError) {
 				if (extensionError != null) {
-					Log.warning("PlacesMonitorInternal : There was an error registering PlacesMonitorListenerPlacesResponseContent for Places Monitor request events: %s",
+					Log.error("PlacesMonitorInternal : There was an error registering PlacesMonitorListenerPlacesResponseContent for Places Monitor request events: %s",
 								extensionError.getErrorName());
 				}
 			}
@@ -90,7 +89,7 @@ class PlacesMonitorInternal extends Extension {
 					@Override
 					public void error(ExtensionError extensionError) {
 						if (extensionError != null) {
-							Log.warning("PlacesMonitorInternal : There was an error registering PlacesMonitorListenerOSResponseContent for OS response events: %s",
+							Log.error("PlacesMonitorInternal : There was an error registering PlacesMonitorListenerOSResponseContent for OS response events: %s",
 									extensionError.getErrorName());
 						}
 					}
@@ -102,25 +101,17 @@ class PlacesMonitorInternal extends Extension {
 		geofenceManager.loadPersistedData();
 		eventQueue = new ConcurrentLinkedQueue<>();
 
-		Context context = App.getAppContext();
-
-		if (context == null) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG,
-						"PlacesMonitorInternal : Context is null, Internal Broadcast receivers not initialized");
-			return;
-		}
-
 		Log.debug(PlacesMonitorConstants.LOG_TAG,"Registering Places Monitoring extension - version %s", PlacesMonitorConstants.EXTENSION_VERSION);
-
 	}
 
 	/**
 	 * Overridden method of {@link Extension} class to handle error occurred during registration of the module.
 	 *
-	 * @param extensionUnexpectedError {@link ExtensionUnexpectedError} occurred exception
+	 * @param extensionUnexpectedError 	{@link ExtensionUnexpectedError} occurred exception
 	 */
 	@Override
 	protected void onUnexpectedError(ExtensionUnexpectedError extensionUnexpectedError) {
+		Log.error(PlacesMonitorConstants.LOG_TAG, String.format("Unexpected error occurred while registering PlacesMonitor extension. Error message %s", extensionUnexpectedError.getMessage()));
 		this.onUnregistered();
 	}
 
@@ -164,7 +155,7 @@ class PlacesMonitorInternal extends Extension {
 	 * {@link PlacesMonitorConstants#NEARBY_GEOFENCES_COUNT} nearby points of interest around the given location.
 	 * The obtained POIs are then passed to {@link #geofenceManager} to start monitoring for entry/exit events.
 	 *
-	 * @param location A {@link Location} instance representing device's current location
+	 * @param location 	A {@link Location} instance representing device's current location
 	 */
 	void getPOIsForLocation(final Location location) {
 		if (location == null) {
@@ -197,7 +188,7 @@ class PlacesMonitorInternal extends Extension {
 	 * The queued events are then processed in an orderly fashion.
 	 * No action is taken if the provided event's value is null.
 	 *
-	 * @param event The {@link Event} thats needs to be queued
+	 * @param event 	The {@link Event} thats needs to be queued
 	 */
 	void queueEvent(final Event event) {
 		if (event == null) {
@@ -262,7 +253,7 @@ class PlacesMonitorInternal extends Extension {
 	 * <p>
 	 * Differentiates the event by the given name and processes them accordingly.
 	 *
-	 * @param event MonitorRequestContent {@link Event} to process
+	 * @param event 	MonitorRequestContent {@link Event} to process
 	 */
 	private void processMonitorRequestEvent(final Event event) {
 		final String eventName = event.getName();
@@ -290,21 +281,36 @@ class PlacesMonitorInternal extends Extension {
 	}
 
 
+	/**
+	 * Method to process OS response event.
+	 *
+	 * <p>
+	 * This function looks for the appropriate eventData keys and processes the following OS Events:
+	 * <ul>
+	 *     <li> Location change event
+	 *     <li> Geofence transition event
+	 *     <li> Permission change event
+	 * </ul>
+	 * This method will not process the event if the eventData doesn't contain the required eventData keys.
+	 *
+	 * @param event 	An OS {@link Event} to be processed
+	 */
 	private void processOSResponseEvent(final Event event) {
 		EventData eventData = event.getData();
 		if(eventData == null || eventData.isEmpty()){
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Received empty eventData , Ignoring event OS event.");
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Received empty eventData , Ignoring OS event.");
 			return;
 		}
 		String eventType;
 		try {
 			eventType = eventData.getString2(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE);
 		} catch (VariantException exception) {
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Invalid eventType for OS responseContent event, Ignoring event OS event.");
-			return; }
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Invalid eventType for OS responseContent event, Ignoring OS event.");
+			return;
+		}
 
 		if(StringUtils.isNullOrEmpty(eventType)){
-			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Null/Empty eventType for OS responseContent event, Ignoring event OS event.");
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Null/Empty eventType for OS responseContent event, Ignoring OS event.");
 			return;
 		}
 
@@ -325,12 +331,17 @@ class PlacesMonitorInternal extends Extension {
 				break;
 			}
 			default: {
-				Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Invalid eventType for OS responseContent event, Ignoring event OS event.");
+				Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Invalid eventType for OS responseContent event, Ignoring OS event.");
 			}
 
 		}
 	}
 
+	/**
+	 * Method to handle the OS event for location permission change.
+	 *
+	 * @param eventData A {@link EventData} of the OS event containing the permission status
+	 */
 	private void handlePermissionChange(final EventData eventData) {
 		String permissionStatus;
 		try {
@@ -366,7 +377,7 @@ class PlacesMonitorInternal extends Extension {
 	/**
 	 * Method to handle the error that occurred while getting the nearbyPointOfInterest.
 	 *
-	 * @param error A {@link PlacesRequestError} representing the type of error
+	 * @param error 	A {@link PlacesRequestError} representing the type of error
 	 */
 	private void handlePlacesRequestError(final PlacesRequestError error) {
 		String errorString = "";

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -338,15 +338,18 @@ class PlacesMonitorInternal extends Extension {
 
 		if(StringUtils.isNullOrEmpty(permissionStatus)){
 			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Null/empty permission status value from the OS responseContent event. Ignoring Permission status change event.");
+			return;
 		}
 
 		switch (permissionStatus){
 			case PlacesMonitorConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_GRANTED: {
 				locationManager.beginLocationTracking();
+				break;
 			}
 			case PlacesMonitorConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_DENIED: {
 				locationManager.stopMonitoring();
 				geofenceManager.stopMonitoringFences(true);
+				break;
 			}
 			default: {
 				Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Invalid permission status value from the OS responseContent event. Ignoring Permission status change event.");

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorInternal.java
@@ -292,6 +292,10 @@ class PlacesMonitorInternal extends Extension {
 
 	private void processOSResponseEvent(final Event event) {
 		EventData eventData = event.getData();
+		if(eventData == null || eventData.isEmpty()){
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "PlacesMonitorInternal : Received empty eventData , Ignoring event OS event.");
+			return;
+		}
 		String eventType;
 		try {
 			eventType = eventData.getString2(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE);

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerHubSharedState.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerHubSharedState.java
@@ -44,12 +44,14 @@ class PlacesMonitorListenerHubSharedState extends ExtensionListener {
 	@Override
 	public void hear(final Event event) {
 		if (event.getEventData() == null) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "EventData is null, ignoring the share state change event.");
 			return;
 		}
 
 		final PlacesMonitorInternal parentExtension = (PlacesMonitorInternal) super.getParentExtension();
 
 		if (parentExtension == null) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "The parent extension, associated with the PlacesMonitorListenerHubSharedState is null, ignoring the share state change event.");
 			return;
 		}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerMonitorRequestContent.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerMonitorRequestContent.java
@@ -53,12 +53,14 @@ class PlacesMonitorListenerMonitorRequestContent extends ExtensionListener {
 	@Override
 	public void hear(final Event event) {
 		if (event.getEventData() == null) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "EventData is null, ignoring the monitor request content event.");
 			return;
 		}
 
 		final PlacesMonitorInternal parentExtension = (PlacesMonitorInternal) super.getParentExtension();
 
 		if (parentExtension == null) {
+			Log.warning(PlacesMonitorConstants.LOG_TAG, "The parent extension, associated with the PlacesMonitorListenerMonitorRequestContent is null, ignoring the monitor request content event.");
 			return;
 		}
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerOSResponseContent.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerOSResponseContent.java
@@ -52,12 +52,14 @@ public class PlacesMonitorListenerOSResponseContent extends ExtensionListener {
     @Override
     public void hear(final Event event) {
         if (event.getEventData() == null) {
+            Log.warning(PlacesMonitorConstants.LOG_TAG, "EventData is null, ignoring the OS response content event.");
             return;
         }
 
         final PlacesMonitorInternal parentExtension = (PlacesMonitorInternal) super.getParentExtension();
 
         if (parentExtension == null) {
+            Log.warning(PlacesMonitorConstants.LOG_TAG, "The parent extension, associated with the PlacesMonitorListenerOSResponseContent is null, ignoring the OS response content event.");
             return;
         }
 

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerOSResponseContent.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorListenerOSResponseContent.java
@@ -1,0 +1,74 @@
+/*
+ Copyright 2019 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+//
+// PlacesMonitorListenerOSResponseContent.java
+//
+
+package com.adobe.marketing.mobile;
+
+/**
+ * Listens for {@link PlacesMonitorConstants.EventType#OS}, {@link PlacesMonitorConstants.EventSource#RESPONSE_CONTENT} events.
+ * <p>
+ * Listens to the following OS events
+ * <ul>
+ *     <li>Significant location change of the device</li>
+ *     <li>Geofence triggers</li>
+ *     <li>Location permission status change</li>
+ * </ul>
+ * @see PlacesMonitorInternal
+ */
+public class PlacesMonitorListenerOSResponseContent extends ExtensionListener {
+
+    /**
+     * Constructor.
+     *
+     * @param extensionApi an instance of  {@link ExtensionApi}
+     * @param type  {@link EventType} this listener is registered to handle
+     * @param source {@link EventSource} this listener is registered to handle
+     */
+    protected PlacesMonitorListenerOSResponseContent(final ExtensionApi extensionApi, final String type, final String source) {
+        super(extensionApi, type, source);
+    }
+
+
+    /**
+     * Method that gets called when {@link PlacesMonitorConstants.EventType#OS},
+     * {@link PlacesMonitorConstants.EventSource#RESPONSE_CONTENT} event is dispatched through eventHub.
+     * <p>
+     * {@link PlacesMonitorInternal} queues event and attempts to process them immediately.
+     *
+     * @param event OS {@link Event} to be processed
+     * @see PlacesMonitorInternal#processEvents()
+     */
+    @Override
+    public void hear(final Event event) {
+        if (event.getEventData() == null) {
+            return;
+        }
+
+        final PlacesMonitorInternal parentExtension = (PlacesMonitorInternal) super.getParentExtension();
+
+        if (parentExtension == null) {
+            return;
+        }
+
+        parentExtension.getExecutor().execute(new Runnable() {
+            @Override
+            public void run() {
+                // handle places monitor request event
+                parentExtension.queueEvent(event);
+                parentExtension.processEvents();
+            }
+        });
+
+    }
+}

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesActivityTests.java
@@ -54,11 +54,16 @@ import static org.mockito.ArgumentMatchers.*;
 
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Context.class, App.class, ActivityCompat.class, Build.class, PlacesMonitor.class, LocationSettingsStates.class, LocalBroadcastManager.class, Intent.class})
+@PrepareForTest({Context.class, App.class, ActivityCompat.class, Build.class, PlacesMonitor.class, LocationSettingsStates.class, Intent.class, MobileCore.class})
 public class PlacesActivityTests {
 	private static final String FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
 	private static final String BACKGROUND_LOCATION = Manifest.permission.ACCESS_BACKGROUND_LOCATION;
 	private static final String INTENT_PERMISSION_KEY = "intent permission key";
+
+
+	// argument captors
+	final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+	final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
 
 	@Mock
 	Context context;
@@ -76,9 +81,6 @@ public class PlacesActivityTests {
 	Intent mockIntent;
 
 	@Mock
-	LocalBroadcastManager localBroadcastManager;
-
-	@Mock
 	LocationSettingsStates locationSettingsStates;
 
 	@Before
@@ -88,6 +90,7 @@ public class PlacesActivityTests {
 		PowerMockito.mockStatic(App.class);
 		PowerMockito.mockStatic(ActivityCompat.class);
 		PowerMockito.mockStatic(LocationSettingsStates.class);
+		PowerMockito.mockStatic(MobileCore.class);
 
 		// set static variables
 		setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 25);
@@ -100,9 +103,6 @@ public class PlacesActivityTests {
 		Mockito.when(placesActivity.getWindow()).thenReturn(window);
 		Mockito.when(placesActivity.getIntent()).thenReturn(mockIntent);
 		Mockito.when(mockIntent.getExtras()).thenReturn(mockExtra);
-
-		PowerMockito.mockStatic(LocalBroadcastManager.class);
-		PowerMockito.when(LocalBroadcastManager.class, "getInstance", any()).thenReturn(localBroadcastManager);
 	}
 
 
@@ -320,8 +320,10 @@ public class PlacesActivityTests {
 	}
 
 	@Test
-	public void test_onRequestPermissionsResult_when_PermissionGranted() throws Exception{
+	public void test_onRequestPermissionsResult_when_PermissionGranted() throws Exception {
 		// test
+		Mockito.when(MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class))).thenReturn(true);
+
 		Mockito.doCallRealMethod().when(placesActivity).onRequestPermissionsResult(anyInt(),  any(String[].class),
 				any(int[].class));
 		placesActivity.onRequestPermissionsResult(PlacesMonitorTestConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE,
@@ -330,10 +332,13 @@ public class PlacesActivityTests {
 
 		// verify
 		verifyOnPermissionGranted();
+
+		// verify the activity is removed from UI
+		verify(placesActivity, times(1)).finish();
 	}
 
 	@Test
-	public void test_onRequestPermissionsResult_when_PermissionDenied() {
+	public void test_onRequestPermissionsResult_when_PermissionDenied() throws Exception {
 		Mockito.doCallRealMethod().when(placesActivity).onRequestPermissionsResult(anyInt(),  any(String[].class),
 				any(int[].class));
 		placesActivity.onRequestPermissionsResult(PlacesMonitorTestConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE,
@@ -414,16 +419,44 @@ public class PlacesActivityTests {
 		field.set(null, newValue);
 	}
 
-	private void verifyOnPermissionDenied() {
-		verify(localBroadcastManager,times(1)).sendBroadcast(any(Intent.class));
+	private void verifyOnPermissionDenied() throws Exception {
+		// The OS permission change event should be dispatched
+		verifyStatic(MobileCore.class, Mockito.times(1));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+
+		// verify dispatched event
+		Event event = eventCaptor.getValue();
+		assertNotNull("The dispatched event should not be null", event);
+		assertEquals("the event name should be correct", PlacesMonitorTestConstants.EVENTNAME_OS_PERMISSION_CHANGE, event.getName());
+		assertEquals("the event type should be correct", PlacesMonitorTestConstants.EventType.OS, event.getType());
+		assertEquals("the event source should be correct", PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT,
+				event.getSource());
+		EventData eventData = event.getData();
+		assertEquals("the event data should contain two element", 2, eventData.size());
+		assertEquals("the event data should contain the right event type", PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_PERMISSION_CHANGE, eventData.getString2(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE));
+		assertEquals("the event data should contain the right permission status", PlacesMonitorConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_DENIED , eventData.getString2(PlacesMonitorConstants.EventDataKey.LOCATION_PERMISSION_STATUS));
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();
 	}
 
 
-	private void verifyOnPermissionGranted() {
-		verify(localBroadcastManager,times(1)).sendBroadcast(any(Intent.class));
+	private void verifyOnPermissionGranted() throws Exception {
+		// The OS permission change event should be dispatched
+		verifyStatic(MobileCore.class, Mockito.times(1));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+
+		// verify dispatched event
+		Event event = eventCaptor.getValue();
+		assertNotNull("The dispatched event should not be null", event);
+		assertEquals("the event name should be correct", PlacesMonitorTestConstants.EVENTNAME_OS_PERMISSION_CHANGE, event.getName());
+		assertEquals("the event type should be correct", PlacesMonitorTestConstants.EventType.OS, event.getType());
+		assertEquals("the event source should be correct", PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT,
+				event.getSource());
+		EventData eventData = event.getData();
+		assertEquals("the event data should contain two element", 2, eventData.size());
+		assertEquals("the event data should contain the right event type", PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_PERMISSION_CHANGE, eventData.getString2(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE));
+		assertEquals("the event data should contain the right permission status", PlacesMonitorConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_GRANTED , eventData.getString2(PlacesMonitorConstants.EventDataKey.LOCATION_PERMISSION_STATUS));
 
 		// verify the activity is removed from UI
 		verify(placesActivity, times(1)).finish();

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiverTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiverTests.java
@@ -17,8 +17,6 @@ package com.adobe.marketing.mobile;
 
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.LocalBroadcastManager;
-
 
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
@@ -43,7 +41,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GeofencingEvent.class, LocalBroadcastManager.class, MobileCore.class, GeofencingEvent.class})
+@PrepareForTest({GeofencingEvent.class, MobileCore.class, GeofencingEvent.class})
 public class PlacesGeofenceBroadcastReceiverTests {
 
 	static final String ACTION_GEOFENCE_UPDATE =
@@ -63,8 +61,6 @@ public class PlacesGeofenceBroadcastReceiverTests {
 	@Mock
 	GeofencingEvent mockGeofencingEvent;
 
-	@Mock
-	LocalBroadcastManager mockBroadcastManager;
 
 	@Before
 	public void before() throws Exception {
@@ -72,6 +68,7 @@ public class PlacesGeofenceBroadcastReceiverTests {
 		PowerMockito.mockStatic(MobileCore.class);
 		PowerMockito.mockStatic(GeofencingEvent.class);
 
+		when(mockIntent.getAction()).thenReturn(ACTION_GEOFENCE_UPDATE);
 
 		receiver = new PlacesGeofenceBroadcastReceiver();
 
@@ -86,7 +83,6 @@ public class PlacesGeofenceBroadcastReceiverTests {
 	@Test
 	public void test_OnReceive_sendOSEvent() throws Exception {
 		// setup
-		initiateMocking();
 		mockGeofenceWithCount(2);
 
 		// test
@@ -120,7 +116,6 @@ public class PlacesGeofenceBroadcastReceiverTests {
 	@Test
 	public void test_OnReceive_when_GeofenceEventHasError() throws Exception {
 		// setup
-		initiateMocking();
 		Mockito.when(mockGeofencingEvent.hasError()).thenReturn(true);
 		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
 
@@ -136,7 +131,6 @@ public class PlacesGeofenceBroadcastReceiverTests {
 	@Test
 	public void test_OnReceive_when_noObtainedGeofence() throws Exception {
 		// setup
-		initiateMocking();
 		mockGeofenceWithCount(0);
 
 		// test
@@ -150,7 +144,6 @@ public class PlacesGeofenceBroadcastReceiverTests {
 	@Test
 	public void test_OnReceive_when_intentIsNull() throws Exception {
 		// setup
-		initiateMocking();
 
 		// test
 		receiver.onReceive(mockContext, null);
@@ -163,7 +156,6 @@ public class PlacesGeofenceBroadcastReceiverTests {
 	@Test
 	public void test_OnReceive_when_intentHasDifferentAction() throws Exception {
 		// setup
-		initiateMocking();
 		when(mockIntent.getAction()).thenReturn("unknownAction");
 
 		// test
@@ -172,14 +164,6 @@ public class PlacesGeofenceBroadcastReceiverTests {
 		// verify no event is dispatched
 		verifyStatic(MobileCore.class, Mockito.times(0));
 		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
-	}
-
-
-	private void initiateMocking() throws Exception {
-		// static mocks
-		PowerMockito.mockStatic(LocalBroadcastManager.class);
-		PowerMockito.when(LocalBroadcastManager.class, "getInstance", any(Context.class)).thenReturn(mockBroadcastManager);
-		when(mockIntent.getAction()).thenReturn(ACTION_GEOFENCE_UPDATE);
 	}
 
 

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiverTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesGeofenceBroadcastReceiverTests.java
@@ -20,28 +20,39 @@ import android.content.Intent;
 import android.support.v4.content.LocalBroadcastManager;
 
 
+import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GeofencingEvent.class, LocalBroadcastManager.class})
+@PrepareForTest({GeofencingEvent.class, LocalBroadcastManager.class, MobileCore.class, GeofencingEvent.class})
 public class PlacesGeofenceBroadcastReceiverTests {
 
 	static final String ACTION_GEOFENCE_UPDATE =
 		"com.adobe.marketing.mobile.PlacesGeofenceBroadcastReceiver.geofenceUpdates";
 	private PlacesGeofenceBroadcastReceiver receiver;
+
+	// argument captors
+	final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+	final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
 
 	@Mock
 	Context mockContext;
@@ -50,11 +61,20 @@ public class PlacesGeofenceBroadcastReceiverTests {
 	Intent mockIntent;
 
 	@Mock
+	GeofencingEvent mockGeofencingEvent;
+
+	@Mock
 	LocalBroadcastManager mockBroadcastManager;
 
 	@Before
 	public void before() throws Exception {
+		// mock the static classes
+		PowerMockito.mockStatic(MobileCore.class);
+		PowerMockito.mockStatic(GeofencingEvent.class);
+
+
 		receiver = new PlacesGeofenceBroadcastReceiver();
+
 		when(mockIntent.getAction()).thenReturn(ACTION_GEOFENCE_UPDATE);
 	}
 
@@ -64,16 +84,67 @@ public class PlacesGeofenceBroadcastReceiverTests {
 
 
 	@Test
-	public void test_OnReceive() throws Exception {
+	public void test_OnReceive_sendOSEvent() throws Exception {
 		// setup
 		initiateMocking();
+		mockGeofenceWithCount(2);
 
 		// test
 		receiver.onReceive(mockContext, mockIntent);
 
-		// verify
-		verify(mockBroadcastManager, times(1)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(1)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
+		// verify the OS event dispatch
+		verifyStatic(MobileCore.class, Mockito.times(1));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+
+		// verify dispatched event
+		Event event = eventCaptor.getValue();
+		assertNotNull("The dispatched event should not be null", event);
+		assertEquals("the event name should be correct", PlacesMonitorTestConstants.EVENTNAME_OS_GEOFENCE_TRIGGER, event.getName());
+		assertEquals("the event type should be correct", PlacesMonitorTestConstants.EventType.OS, event.getType());
+		assertEquals("the event source should be correct", PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT,
+				event.getSource());
+		// evaluate the eventData
+		EventData eventData = event.getData();
+		assertEquals("the event data should contain two element", 3, eventData.size());
+		assertEquals("the event data should contain the correct  event type", PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_GEOFENCE_TRIGGER, eventData.getString2(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE));
+		assertEquals("the event data should contain the correct  geofence transition type", Geofence.GEOFENCE_TRANSITION_EXIT , eventData.getInteger(PlacesMonitorConstants.EventDataKey.GEOFENCE_TRANSITION_TYPE));
+
+		// evaluate the geofenceIds
+		List<String> obtainedGeofenceIds = eventData.getStringList(PlacesMonitorConstants.EventDataKey.GEOFENCE_IDS);
+		assertEquals("the event data should contain the correct geofence ids count", 2 ,  obtainedGeofenceIds.size());
+		assertEquals("the event data should contain the correct geofence ids", "id0" ,  obtainedGeofenceIds.get(0));
+		assertEquals("the event data should contain the correct geofence ids", "id1" ,  obtainedGeofenceIds.get(1));
+	}
+
+
+	@Test
+	public void test_OnReceive_when_GeofenceEventHasError() throws Exception {
+		// setup
+		initiateMocking();
+		Mockito.when(mockGeofencingEvent.hasError()).thenReturn(true);
+		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
+
+		// test
+		receiver.onReceive(mockContext, mockIntent);
+
+		// verify no event is dispatched
+		verifyStatic(MobileCore.class, Mockito.times(0));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+	}
+
+
+	@Test
+	public void test_OnReceive_when_noObtainedGeofence() throws Exception {
+		// setup
+		initiateMocking();
+		mockGeofenceWithCount(0);
+
+		// test
+		receiver.onReceive(mockContext, mockIntent);
+
+		// verify no event is dispatched
+		verifyStatic(MobileCore.class, Mockito.times(0));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
 	}
 
 	@Test
@@ -84,9 +155,9 @@ public class PlacesGeofenceBroadcastReceiverTests {
 		// test
 		receiver.onReceive(mockContext, null);
 
-		// verify
-		verify(mockBroadcastManager, times(0)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(0)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
+		// verify no event is dispatched
+		verifyStatic(MobileCore.class, Mockito.times(0));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
 	}
 
 	@Test
@@ -98,24 +169,11 @@ public class PlacesGeofenceBroadcastReceiverTests {
 		// test
 		receiver.onReceive(mockContext, mockIntent);
 
-		// verify
-		verify(mockBroadcastManager, times(0)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(0)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
+		// verify no event is dispatched
+		verifyStatic(MobileCore.class, Mockito.times(0));
+		MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
 	}
 
-
-	@Test
-	public void test_OnReceive_when_contextIsNull() throws Exception {
-		// setup
-		initiateMocking();
-
-		// test
-		receiver.onReceive(null, mockIntent);
-
-		// verify
-		verify(mockBroadcastManager, times(0)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(0)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
-	}
 
 	private void initiateMocking() throws Exception {
 		// static mocks
@@ -123,4 +181,21 @@ public class PlacesGeofenceBroadcastReceiverTests {
 		PowerMockito.when(LocalBroadcastManager.class, "getInstance", any(Context.class)).thenReturn(mockBroadcastManager);
 		when(mockIntent.getAction()).thenReturn(ACTION_GEOFENCE_UPDATE);
 	}
+
+
+	private void mockGeofenceWithCount(int count) throws Exception {
+		List<Geofence> obtainedGeofence = new ArrayList<>();
+		for(int i=0; i<count; i++){
+			Geofence geofence = new Geofence.Builder().setRequestId("id" + i).setTransitionTypes(
+					Geofence.GEOFENCE_TRANSITION_EXIT).setCircularRegion(22.33, -33.33,
+					100).setExpirationDuration(Geofence.NEVER_EXPIRE).build();
+			obtainedGeofence.add(geofence);
+		}
+
+
+		Mockito.when(mockGeofencingEvent.getTriggeringGeofences()).thenReturn(obtainedGeofence);
+		Mockito.when(mockGeofencingEvent.getGeofenceTransition()).thenReturn(Geofence.GEOFENCE_TRANSITION_EXIT);
+		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
+	}
+
 }

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesGeofenceManagerTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesGeofenceManagerTests.java
@@ -25,7 +25,6 @@ import android.support.v4.app.ActivityCompat;
 
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingClient;
-import com.google.android.gms.location.GeofencingEvent;
 import com.google.android.gms.location.GeofencingRequest;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -47,6 +46,7 @@ import org.powermock.reflect.Whitebox;
 
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Context.class, App.class, LocationServices.class, PendingIntent.class, ActivityCompat.class, Intent.class, Places.class, GeofencingEvent.class})
+@PrepareForTest({Context.class, App.class, LocationServices.class, PendingIntent.class, ActivityCompat.class, Places.class})
 public class PlacesGeofenceManagerTests {
 	static private String MONITOR_SHARED_PREFERENCE_KEY = "com.adobe.placesMonitor";
 	private final String FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
@@ -71,12 +71,6 @@ public class PlacesGeofenceManagerTests {
 
 	@Mock
 	Context context;
-
-	@Mock
-	GeofencingEvent mockGeofencingEvent;
-
-	@Mock
-	Intent intent;
 
 	@Mock
 	GeofencingClient geofencingClient;
@@ -101,11 +95,10 @@ public class PlacesGeofenceManagerTests {
 
 
 	@Before
-	public void before() throws Exception {
+	public void before()  {
 		PowerMockito.mockStatic(App.class);
 		PowerMockito.mockStatic(Places.class);
 		PowerMockito.mockStatic(LocationServices.class);
-		PowerMockito.mockStatic(GeofencingEvent.class);
 		PowerMockito.mockStatic(PendingIntent.class);
 		PowerMockito.mockStatic(ActivityCompat.class);
 
@@ -240,7 +233,6 @@ public class PlacesGeofenceManagerTests {
 		verifyStatic(Places.class, Mockito.times(2));
 		Places.processGeofence(any(Geofence.class), eq(Geofence.GEOFENCE_TRANSITION_ENTER));
 	}
-
 
 	@Test
 	public void test_startMonitoringFences_addFence_throwsSecurityException() {
@@ -385,7 +377,6 @@ public class PlacesGeofenceManagerTests {
 		verify(mockSharedPreference, times(0)).edit();
 	}
 
-
 	@Test
 	public void test_stopMonitoringFences_then_FailedToStopMonitor() {
 		// setup
@@ -403,7 +394,6 @@ public class PlacesGeofenceManagerTests {
 		// trigger the failure callback
 		onFailureCallback.getValue().onFailure(new Exception());
 	}
-
 
 	@Test
 	public void test_stopMonitoringFences_when_geofencingClient_isNull() {
@@ -430,7 +420,6 @@ public class PlacesGeofenceManagerTests {
 		verify(geofencingClient, times(0)).removeGeofences(geofencePendingIntent);
 	}
 
-
 	@Test
 	public void test_stopMonitoringFences_when_context_isNull() {
 		// setup
@@ -443,54 +432,40 @@ public class PlacesGeofenceManagerTests {
 		verify(geofencingClient, times(0)).removeGeofences(geofencePendingIntent);
 	}
 
-	// ========================================================================================
-	// onGeofenceReceived
-	// ========================================================================================
+
+    // ========================================================================================
+    // onGeofenceTransitionReceived
+    // ========================================================================================
 
 	@Test
-	public void test_onGeofenceReceived() throws Exception {
+	public void test_onGeofenceTransitionReceived() {
 		// setup
-		List<Geofence> obtainedGeofence = new ArrayList<>();
-		Geofence geofence = new Geofence.Builder().setRequestId("id1").setTransitionTypes(
-			Geofence.GEOFENCE_TRANSITION_ENTER).setCircularRegion(22.33, -33.33,
-					100).setExpirationDuration(Geofence.NEVER_EXPIRE).build();
-		obtainedGeofence.add(geofence);
-
-		Mockito.when(mockGeofencingEvent.getTriggeringGeofences()).thenReturn(obtainedGeofence);
-		Mockito.when(mockGeofencingEvent.getGeofenceTransition()).thenReturn(Geofence.GEOFENCE_TRANSITION_ENTER);
-		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
-		when(intent.getAction()).thenReturn(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
-
+        final ArgumentCaptor<Geofence> geofenceCaptor = ArgumentCaptor.forClass(Geofence.class);
+        List<String> geofenceTransitionIDs  = new ArrayList<>();
+        geofenceTransitionIDs.add("id1");
 
 		// test
-		geofenceManager.onGeofenceReceived(intent);
+		geofenceManager.onGeofenceTriggerReceived(geofenceTransitionEventData(geofenceTransitionIDs,Geofence.GEOFENCE_TRANSITION_ENTER));
 
 		// verify
 		verifyStatic(Places.class, Mockito.times(1));
-		Places.processGeofence(geofence, Geofence.GEOFENCE_TRANSITION_ENTER);
+		Places.processGeofence(geofenceCaptor.capture() , eq(Geofence.GEOFENCE_TRANSITION_ENTER));
+		assertEquals("id1", geofenceCaptor.getValue().getRequestId());
 	}
 
 	@Test
-	public void test_onGeofenceReceived_ForEntry_whenPOIAlreadyEntered() throws Exception {
+	public void test_onGeofenceTransitionReceived_ForEntry_whenPOIAlreadyEntered() {
 		// setup
 		HashSet<String> initialUserWithinGeofenceSet = new HashSet<String>();
 		initialUserWithinGeofenceSet.add("id1");
 		Whitebox.setInternalState(geofenceManager, "userWithinGeofences", initialUserWithinGeofenceSet);
 
-		List<Geofence> obtainedGeofence = new ArrayList<>();
-		Geofence geofence = new Geofence.Builder().setRequestId("id1").setTransitionTypes(
-			Geofence.GEOFENCE_TRANSITION_ENTER).setCircularRegion(22.33, -33.33,
-					100).setExpirationDuration(Geofence.NEVER_EXPIRE).build();
-		obtainedGeofence.add(geofence);
-
-		Mockito.when(mockGeofencingEvent.getTriggeringGeofences()).thenReturn(obtainedGeofence);
-		Mockito.when(mockGeofencingEvent.getGeofenceTransition()).thenReturn(Geofence.GEOFENCE_TRANSITION_ENTER);
-		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
-		when(intent.getAction()).thenReturn(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
-
+        // prepare the geofence id for the OS Event
+        List<String> geofenceTransitionIDs  = new ArrayList<>();
+        geofenceTransitionIDs.add("id1");
 
 		// test
-		geofenceManager.onGeofenceReceived(intent);
+        geofenceManager.onGeofenceTriggerReceived(geofenceTransitionEventData(geofenceTransitionIDs,Geofence.GEOFENCE_TRANSITION_ENTER));
 
 		// verify
 		verifyStatic(Places.class, Mockito.times(0));
@@ -498,83 +473,88 @@ public class PlacesGeofenceManagerTests {
 	}
 
 	@Test
-	public void test_onGeofenceReceived_ForExit_whenPOIAlreadyEntered() throws Exception {
+	public void test_onGeofenceTransitionReceived_ForExit_whenPOIAlreadyEntered() {
 		// setup
+        final ArgumentCaptor<Geofence> geofenceCaptor = ArgumentCaptor.forClass(Geofence.class);
 		HashSet<String> initialUserWithinGeofenceSet = new HashSet<String>();
 		initialUserWithinGeofenceSet.add("id1");
 		Whitebox.setInternalState(geofenceManager, "userWithinGeofences", initialUserWithinGeofenceSet);
 
-		List<Geofence> obtainedGeofence = new ArrayList<>();
-		Geofence geofence = new Geofence.Builder().setRequestId("id1").setTransitionTypes(
-			Geofence.GEOFENCE_TRANSITION_EXIT).setCircularRegion(22.33, -33.33,
-					100).setExpirationDuration(Geofence.NEVER_EXPIRE).build();
-		obtainedGeofence.add(geofence);
+        // prepare the geofenceIDs for the OS Event
+        List<String> geofenceTransitionIDs  = new ArrayList<>();
+        geofenceTransitionIDs.add("id1");
 
-		Mockito.when(mockGeofencingEvent.getTriggeringGeofences()).thenReturn(obtainedGeofence);
-		Mockito.when(mockGeofencingEvent.getGeofenceTransition()).thenReturn(Geofence.GEOFENCE_TRANSITION_EXIT);
-		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
-		when(intent.getAction()).thenReturn(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
-
-
-		// test
-		geofenceManager.onGeofenceReceived(intent);
+        // test
+        geofenceManager.onGeofenceTriggerReceived(geofenceTransitionEventData(geofenceTransitionIDs,Geofence.GEOFENCE_TRANSITION_EXIT));
 
 		// verify
 		verifyStatic(Places.class, Mockito.times(1));
-		Places.processGeofence(geofence, Geofence.GEOFENCE_TRANSITION_EXIT);
+		Places.processGeofence(geofenceCaptor.capture(), eq(Geofence.GEOFENCE_TRANSITION_EXIT));
 
 		// verify result
 		HashSet<String> resultUserWithInGeofences = Whitebox.getInternalState(geofenceManager, "userWithinGeofences");
 		assertEquals(0, resultUserWithInGeofences.size());
+        assertEquals("id1", geofenceCaptor.getValue().getRequestId());
 	}
 
 	@Test
-	public void test_onGeofenceReceived_ForExit_whenPOINotAlreadyEntered() throws Exception {
+	public void test_onGeofenceTransitionReceived_ForExit_whenPOINotAlreadyEntered() {
 		// setup
+        final ArgumentCaptor<Geofence> geofenceCaptor = ArgumentCaptor.forClass(Geofence.class);
 		Whitebox.setInternalState(geofenceManager, "userWithinGeofences", new HashSet<String>());
 
-		List<Geofence> obtainedGeofence = new ArrayList<>();
-		Geofence geofence = new Geofence.Builder().setRequestId("id1").setTransitionTypes(
-			Geofence.GEOFENCE_TRANSITION_EXIT).setCircularRegion(22.33, -33.33,
-					100).setExpirationDuration(Geofence.NEVER_EXPIRE).build();
-		obtainedGeofence.add(geofence);
-
-		Mockito.when(mockGeofencingEvent.getTriggeringGeofences()).thenReturn(obtainedGeofence);
-		Mockito.when(mockGeofencingEvent.getGeofenceTransition()).thenReturn(Geofence.GEOFENCE_TRANSITION_EXIT);
-		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
-		when(intent.getAction()).thenReturn(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
+        // prepare the geofenceIDs for the OS Event
+        List<String> geofenceTransitionIDs  = new ArrayList<>();
+        geofenceTransitionIDs.add("id1");
 
 		// test
-		geofenceManager.onGeofenceReceived(intent);
+        geofenceManager.onGeofenceTriggerReceived(geofenceTransitionEventData(geofenceTransitionIDs,Geofence.GEOFENCE_TRANSITION_EXIT));
 
 		// verify that exit event goes out, if the poi is not already entered.
 		verifyStatic(Places.class, Mockito.times(1));
-		Places.processGeofence(geofence, Geofence.GEOFENCE_TRANSITION_EXIT);
+		Places.processGeofence(geofenceCaptor.capture(), eq(Geofence.GEOFENCE_TRANSITION_EXIT));
 
 		// verify result
 		HashSet<String> resultUserWithInGeofences = Whitebox.getInternalState(geofenceManager, "userWithinGeofences");
 		assertEquals(0, resultUserWithInGeofences.size());
+        assertEquals("id1", geofenceCaptor.getValue().getRequestId());
 	}
 
+    @Test
+    public void test_onGeofenceTransitionReceived_with_noGeofences(){
+        // setup
+        Whitebox.setInternalState(geofenceManager, "userWithinGeofences", new HashSet<String>());
+
+        // test
+        geofenceManager.onGeofenceTriggerReceived(geofenceTransitionEventData(new ArrayList<String>(),Geofence.GEOFENCE_TRANSITION_EXIT));
+
+        // verify
+        verifyStatic(Places.class, Mockito.times(0));
+        Places.processGeofence(any(Geofence.class), anyInt());
+        HashSet<String> resultUserWithInGeofences = Whitebox.getInternalState(geofenceManager, "userWithinGeofences");
+        assertEquals(0, resultUserWithInGeofences.size());
+    }
+
+    @Test
+    public void test_onGeofenceTransitionReceived_with_invalidEventData(){
+        // setup
+        Whitebox.setInternalState(geofenceManager, "userWithinGeofences", new HashSet<String>());
+
+        // test
+        geofenceManager.onGeofenceTriggerReceived(new EventData());
+
+        // verify
+        verifyStatic(Places.class, Mockito.times(0));
+        Places.processGeofence(any(Geofence.class), anyInt());
+        HashSet<String> resultUserWithInGeofences = Whitebox.getInternalState(geofenceManager, "userWithinGeofences");
+        assertEquals(0, resultUserWithInGeofences.size());
+    }
 
 
-	@Test
-	public void test_onGeofenceReceived_when_nullIntent() throws Exception {
-		// setup
-		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
-		when(intent.getAction()).thenReturn(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
-
-		// test
-		geofenceManager.onGeofenceReceived(null);
-
-		// verify
-		verifyStatic(Places.class, Mockito.times(0));
-		Places.processGeofenceEvent(mockGeofencingEvent);
-	}
-
-	// ========================================================================================
+    // ========================================================================================
 	// findNewlyEnteredPOIs
 	// ========================================================================================
+
 	@Test
 	public void test_findNewlyEnteredPOIs_when_noInitiallyEnteredPOIs() {
 		// setup
@@ -639,7 +619,6 @@ public class PlacesGeofenceManagerTests {
 		assertEquals("id4", newlyEnteredPOI.get(0).getIdentifier());
 	}
 
-
 	@Test
 	public void test_findNewlyEnteredPOIs_when_removesAllPOIsIfthereAreNoNearByPOIS() {
 		// setup
@@ -657,35 +636,6 @@ public class PlacesGeofenceManagerTests {
 
 		// verify newlyEntered POI
 		assertEquals(0, newlyEnteredPOI.size());
-	}
-
-	@Test
-	public void test_onGeofenceReceived_when_unknownAction() throws Exception {
-		// setup
-		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
-		when(intent.getAction()).thenReturn("unknown action");
-
-		// test
-		geofenceManager.onGeofenceReceived(intent);
-
-		// verify
-		verifyStatic(Places.class, Mockito.times(0));
-		Places.processGeofenceEvent(mockGeofencingEvent);
-	}
-
-	@Test
-	public void test_onGeofenceReceived_when_GeofenceEventHasError() throws Exception {
-		// setup
-		PowerMockito.when(GeofencingEvent.class, "fromIntent", any(Intent.class)).thenReturn(mockGeofencingEvent);
-		when(intent.getAction()).thenReturn(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_GEOFENCE);
-		when(mockGeofencingEvent.hasError()).thenReturn(true);
-
-		// test
-		geofenceManager.onGeofenceReceived(intent);
-
-		// verify
-		verifyStatic(Places.class, Mockito.times(0));
-		Places.processGeofenceEvent(mockGeofencingEvent);
 	}
 
 	// ========================================================================================
@@ -753,7 +703,6 @@ public class PlacesGeofenceManagerTests {
 		assertEquals(pois, persistedPOICaptor.getValue());
 	}
 
-
 	@Test
 	public void test_saveUserWithinGeofences_when_sharedPreference_isNull() {
 		// setup
@@ -805,7 +754,6 @@ public class PlacesGeofenceManagerTests {
 		// verify
 		assertNull(intent);
 	}
-
 
 	@Test
 	public void test_getSharedPreference_when_context_isNull() throws Exception {
@@ -895,5 +843,11 @@ public class PlacesGeofenceManagerTests {
 		return pois;
 	}
 
+    private EventData geofenceTransitionEventData(final List<String> geofenceIDs, final int transitionType) {
+        return new EventData(new HashMap<String,Variant>()
+        {{ put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, Variant.fromString(PlacesMonitorTestConstants.EventDataValue.OS_EVENT_TYPE_GEOFENCE_TRIGGER));
+            put(PlacesMonitorConstants.EventDataKey.GEOFENCE_IDS, Variant.fromStringList(geofenceIDs));
+            put(PlacesMonitorConstants.EventDataKey.GEOFENCE_TRANSITION_TYPE, Variant.fromInteger(transitionType));}});
+    }
 
 }

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationBroadcastReceiverTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationBroadcastReceiverTests.java
@@ -18,34 +18,50 @@ package com.adobe.marketing.mobile;
 
 import android.content.Context;
 import android.content.Intent;
+import android.location.Location;
+import android.location.LocationManager;
 import android.support.v4.content.LocalBroadcastManager;
 
+import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({LocationResult.class, LocalBroadcastManager.class})
+@PrepareForTest({LocationResult.class,  MobileCore.class})
 public class PlacesLocationBroadcastReceiverTests {
 
-	static final String ACTION_LOCATION_UPDATE =
-		"com.adobe.marketing.mobile.PlacesLocationBroadcastReceiver.locationUpdates";
+    static final String ACTION_LOCATION_UPDATE =
+            "com.adobe.marketing.mobile.PlacesLocationBroadcastReceiver.locationUpdates";
+
+    // argument captors
+    final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+    final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
+
 	private PlacesLocationBroadcastReceiver receiver;
+    private LocationResult locationResult;
 
 	@Mock
 	Context mockContext;
@@ -53,12 +69,14 @@ public class PlacesLocationBroadcastReceiverTests {
 	@Mock
 	Intent mockIntent;
 
-	@Mock
-	LocalBroadcastManager mockBroadcastManager;
+    @Mock
+    Location mockLocation1, mockLocation2;
 
 	@Before
 	public void before() throws Exception {
-		receiver = new PlacesLocationBroadcastReceiver();
+        PowerMockito.mockStatic(MobileCore.class);
+        when(mockIntent.getAction()).thenReturn(ACTION_LOCATION_UPDATE);
+        receiver = new PlacesLocationBroadcastReceiver();
 	}
 
 	// ========================================================================================
@@ -66,66 +84,122 @@ public class PlacesLocationBroadcastReceiverTests {
 	// ========================================================================================
 
 	@Test
-	public void test_OnReceive() throws Exception {
+	public void test_OnReceive_sendsOSEvent() throws Exception {
 		// setup
-		initiateMocking();
+		initiateLocationMocking();
 
 		// test
 		receiver.onReceive(mockContext, mockIntent);
 
-		// verify
-		verify(mockBroadcastManager, times(1)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(1)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_LOCATION);
+        // verify the OS event dispatch
+        verifyStatic(MobileCore.class, Mockito.times(1));
+        MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+
+        // verify dispatched event
+        Event event = eventCaptor.getValue();
+        assertNotNull("The dispatched event should not be null", event);
+        assertEquals("the event name should be correct", PlacesMonitorTestConstants.EVENTNAME_OS_LOCATION_UPDATE, event.getName());
+        assertEquals("the event type should be correct", PlacesMonitorTestConstants.EventType.OS, event.getType());
+        assertEquals("the event source should be correct", PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT,
+                event.getSource());
+        // evaluate the eventData
+        EventData eventData = event.getData();
+        assertEquals("the event data should contain two element", 3, eventData.size());
+        assertEquals("the event data should contain the correct  event type", PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_UPDATE, eventData.getString2(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE));
+        assertEquals("the event data should contain the correct latitude",33.33, eventData.getDouble(PlacesMonitorConstants.EventDataKey.LATITUDE), 0);
+        assertEquals("the event data should contain the correct longitude", 22.22, eventData.getDouble(PlacesMonitorConstants.EventDataKey.LONGITUDE), 0);
 	}
 
 	@Test
 	public void test_OnReceive_when_intentIsNull() throws Exception {
 		// setup
-		initiateMocking();
+        initiateLocationMocking();
 
 		// test
 		receiver.onReceive(mockContext, null);
 
-		// verify
-		verify(mockBroadcastManager, times(0)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(0)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_LOCATION);
+        // verify OS event is not dispatched
+        verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
 	}
 
 	@Test
 	public void test_OnReceive_when_intentHasDifferentAction() throws Exception {
 		// setup
-		initiateMocking();
+        initiateLocationMocking();
 		when(mockIntent.getAction()).thenReturn("unknownAction");
 
 		// test
 		receiver.onReceive(mockContext, mockIntent);
 
-		// verify
-		verify(mockBroadcastManager, times(0)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(0)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_LOCATION);
+        // verify OS event is not dispatched
+        verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
 	}
 
 
 	@Test
-	public void test_OnReceive_when_contextIsNull() throws Exception {
+	public void test_OnReceive_when_locationListIsEmpty() throws Exception {
 		// setup
-		initiateMocking();
+        List<Location> locationList = new ArrayList<>();
+        locationResult = LocationResult.create(locationList);
+        PowerMockito.mockStatic(LocationResult.class);
+        PowerMockito.when(LocationResult.class, "extractResult", any(Intent.class)).thenReturn(locationResult);
 
 		// test
 		receiver.onReceive(null, mockIntent);
 
-		// verify
-		verify(mockBroadcastManager, times(0)).sendBroadcast(mockIntent);
-		verify(mockIntent, times(0)).setAction(PlacesMonitorConstants.INTERNAL_INTENT_ACTION_LOCATION);
+        // verify OS event is not dispatched
+        verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
 	}
 
-	private void initiateMocking() throws Exception {
-		// static mocks
-		PowerMockito.mockStatic(LocalBroadcastManager.class);
-		PowerMockito.mockStatic(LocationResult.class);
-		PowerMockito.when(LocalBroadcastManager.class, "getInstance", any(Context.class)).thenReturn(mockBroadcastManager);
+    @Test
+    public void test_OnReceive_when_locationIsNull() throws Exception {
+        // setup
+        List<Location> locationList = new ArrayList<>();
+        locationList.add(null);
+        locationResult = LocationResult.create(locationList);
 
-		when(mockIntent.getAction()).thenReturn(ACTION_LOCATION_UPDATE);
-	}
+        PowerMockito.mockStatic(LocationResult.class);
+        PowerMockito.when(LocationResult.class, "extractResult", any(Intent.class)).thenReturn(locationResult);
+
+        // test
+        receiver.onReceive(null, mockIntent);
+
+        // verify OS event is not dispatched
+        verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+    }
+
+
+    @Test
+    public void test_OnReceive_when_locationListIsNull() throws Exception {
+        // setup
+        locationResult = LocationResult.create(null);
+
+        // test
+        receiver.onReceive(null, mockIntent);
+
+        // verify OS event is not dispatched
+        verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(eventCaptor.capture(), callbackCaptor.capture());
+    }
+
+    private void initiateLocationMocking() throws Exception {
+        // static mocks
+        when(mockLocation1.getLatitude()).thenReturn(33.33);
+        when(mockLocation1.getLongitude()).thenReturn(22.22);
+        when(mockLocation2.getLatitude()).thenReturn(44.44);
+        when(mockLocation2.getLongitude()).thenReturn(55.55);
+
+        List<Location> locationList = new ArrayList<>();
+        locationList.add(mockLocation1);
+        locationList.add(mockLocation2);
+        locationResult = LocationResult.create(locationList);
+
+        PowerMockito.mockStatic(LocationResult.class);
+        PowerMockito.when(LocationResult.class, "extractResult", any(Intent.class)).thenReturn(locationResult);
+    }
 
 }

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationManagerTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesLocationManagerTests.java
@@ -688,7 +688,7 @@ public class PlacesLocationManagerTests {
 	// ========================================================================================
 
 	@Test
-    public void test_onLocationReceived() {
+    public void test_onLocationReceived(){
         // setup
         final ArgumentCaptor<Location> locationCaptor = ArgumentCaptor.forClass(Location.class);
 
@@ -701,7 +701,7 @@ public class PlacesLocationManagerTests {
     }
 
     @Test
-    public void test_onLocationReceived_InvalidLatitude() throws Exception {
+    public void test_onLocationReceived_InvalidLatitude(){
         // test
         locationManager.onLocationReceived(locationUpdateEventData(222.22,33.33));
 
@@ -710,7 +710,7 @@ public class PlacesLocationManagerTests {
     }
 
     @Test
-    public void test_onLocationReceived_InvalidLongitude() throws Exception {
+    public void test_onLocationReceived_InvalidLongitude(){
         // test
         locationManager.onLocationReceived(locationUpdateEventData(22.22,333.33));
 
@@ -719,7 +719,7 @@ public class PlacesLocationManagerTests {
     }
 
     @Test
-    public void test_onLocationReceived_EventDataWithInvalidLatitudeDataType() throws Exception {
+    public void test_onLocationReceived_EventDataWithInvalidLatitudeDataType(){
 	    // setup
         EventData eventData = new EventData(new HashMap<String,Variant>()
         {{put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, Variant.fromString(PlacesMonitorTestConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_UPDATE));

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorInternalTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorInternalTests.java
@@ -22,12 +22,11 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.location.Location;
-import android.support.v4.content.LocalBroadcastManager;
+
+import com.google.android.gms.location.Geofence;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -49,13 +48,21 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ExtensionApi.class, PlacesLocationManager.class, PlacesGeofenceManager.class, PlacesMonitorInternal.class, App.class, Context.class, Intent.class, LocalBroadcastManager.class, Places.class, Location.class})
+@PrepareForTest({ExtensionApi.class, PlacesLocationManager.class, PlacesGeofenceManager.class, PlacesMonitorInternal.class, App.class, Context.class, Intent.class, Places.class, Location.class})
 public class PlacesMonitorInternalTests {
 	private PlacesMonitorInternal monitorInternal;
 
 	private Event startMonitoringEvent = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_START,
 			PlacesMonitorTestConstants.EventType.MONITOR,
 			PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT).build();
+
+    private Event OSLocationEvent = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_OS_LOCATION_UPDATE,
+            PlacesMonitorTestConstants.EventType.OS,
+            PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT).setData(locationUpdateEventData()).build();
+
+    private Event OSGeofenceEvent = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_OS_GEOFENCE_TRIGGER,
+            PlacesMonitorTestConstants.EventType.OS,
+            PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT).setData(geofenceTransitionEventData()).build();
 
 	private Event stopMonitoringEvent = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_STOP,
 			PlacesMonitorTestConstants.EventType.MONITOR,
@@ -64,12 +71,12 @@ public class PlacesMonitorInternalTests {
 	private Event stopMonitoringEventWithClearData = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_STOP,
 			PlacesMonitorTestConstants.EventType.MONITOR,
 			PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT).setData(new EventData(new HashMap<String,Variant>()
-	{{ put(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_CLEAR, Variant.fromBoolean(true)); }})).build();
+	{{ put(PlacesMonitorConstants.EventDataKey.CLEAR, Variant.fromBoolean(true)); }})).build();
 
 	private Event stopMonitoringEventWithOutClearData = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_STOP,
 			PlacesMonitorTestConstants.EventType.MONITOR,
 			PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT).setData(new EventData(new HashMap<String,Variant>()
-	{{ put(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_CLEAR, Variant.fromBoolean(false)); }})).build();
+	{{ put(PlacesMonitorConstants.EventDataKey.CLEAR, Variant.fromBoolean(false)); }})).build();
 
 	private Event updateLocationEvent = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_UPDATE,
 			PlacesMonitorTestConstants.EventType.MONITOR,
@@ -78,7 +85,7 @@ public class PlacesMonitorInternalTests {
 	private Event setLocationPermissionEvent = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_SET_LOCATION_PERMISSION,
 			PlacesMonitorTestConstants.EventType.MONITOR,
 			PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT).setData(new EventData(new HashMap<String,Variant>()
-	{{ put(PlacesMonitorConstants.EventDataKeys.EVENT_DATA_LOCATION_PERMISSION, Variant.fromString(PlacesMonitorLocationPermission.WHILE_USING_APP.getValue())); }})).build();
+	{{ put(PlacesMonitorConstants.EventDataKey.LOCATION_PERMISSION, Variant.fromString(PlacesMonitorLocationPermission.WHILE_USING_APP.getValue())); }})).build();
 
 	private Event setLocationPermissionEventNoEventData = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_SET_LOCATION_PERMISSION,
 			PlacesMonitorTestConstants.EventType.MONITOR,
@@ -88,7 +95,6 @@ public class PlacesMonitorInternalTests {
 			PlacesMonitorTestConstants.EventType.MONITOR,
 			PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT).build();
 
-
 	@Mock
 	Location location;
 
@@ -96,10 +102,7 @@ public class PlacesMonitorInternalTests {
 	Context context;
 
 	@Mock
-	Intent intent;
-
-	@Mock
-	LocalBroadcastManager localBroadcastManager;
+    ExtensionUnexpectedError extensionUnexpectedError;
 
 	@Mock
 	ExtensionApi extensionApi;
@@ -114,8 +117,6 @@ public class PlacesMonitorInternalTests {
 	public void before() throws Exception {
 		PowerMockito.mockStatic(App.class);
 		PowerMockito.mockStatic(Places.class);
-		PowerMockito.mockStatic(LocalBroadcastManager.class);
-		Mockito.when(LocalBroadcastManager.getInstance(context)).thenReturn(localBroadcastManager);
 		PowerMockito.whenNew(PlacesGeofenceManager.class).withNoArguments().thenReturn(geofenceManager);
 	}
 
@@ -129,8 +130,9 @@ public class PlacesMonitorInternalTests {
 		initWithContext(context);
 		final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor1 = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
 		final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor2 = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
+		final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor3 = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
 
-		// verify 2 listeners are registered
+		// verify 3 listeners are registered
 		verify(extensionApi, times(1)).registerEventListener(eq(PlacesMonitorConstants.EventType.HUB),
 				eq(PlacesMonitorConstants.EventSource.SHARED_STATE), eq(PlacesMonitorListenerHubSharedState.class),
 				callbackCaptor1.capture());
@@ -138,19 +140,23 @@ public class PlacesMonitorInternalTests {
 				eq(PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT), eq(PlacesMonitorListenerMonitorRequestContent.class),
 				callbackCaptor2.capture());
 
+		verify(extensionApi, times(1)).registerEventListener(eq(PlacesMonitorTestConstants.EventType.OS),
+				eq(PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT), eq(PlacesMonitorListenerOSResponseContent.class),
+				callbackCaptor3.capture());
+
 		// verify that loadFences is called
 		verify(geofenceManager, times(1)).loadPersistedData();
 
 		// verify register listener error callback are not null
 		assertNotNull("The register listener error callback should not be null", callbackCaptor1.getValue());
 		assertNotNull("The register listener error callback should not be null", callbackCaptor2.getValue());
+		assertNotNull("The register listener error callback should not be null", callbackCaptor3.getValue());
 
-		// verify that the internal receivers are registered
-		verify(localBroadcastManager, times(4)).registerReceiver(any(BroadcastReceiver.class), any(IntentFilter.class));
 
 		// calling the callback should not crash
 		callbackCaptor1.getValue().error(ExtensionError.UNEXPECTED_ERROR);
 		callbackCaptor2.getValue().error(ExtensionError.UNEXPECTED_ERROR);
+		callbackCaptor3.getValue().error(ExtensionError.UNEXPECTED_ERROR);
 	}
 
 	@Test
@@ -162,7 +168,7 @@ public class PlacesMonitorInternalTests {
 		final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor1 = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
 		final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor2 = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
 
-		// verify 2 listeners are registered
+		// verify 3 listeners are registered
 		verify(extensionApi, times(1)).registerEventListener(eq(PlacesMonitorConstants.EventType.HUB),
 				eq(PlacesMonitorConstants.EventSource.SHARED_STATE), eq(PlacesMonitorListenerHubSharedState.class),
 				callbackCaptor1.capture());
@@ -170,11 +176,12 @@ public class PlacesMonitorInternalTests {
 				eq(PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT), eq(PlacesMonitorListenerMonitorRequestContent.class),
 				callbackCaptor2.capture());
 
+		verify(extensionApi, times(1)).registerEventListener(eq(PlacesMonitorTestConstants.EventType.MONITOR),
+				eq(PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT), eq(PlacesMonitorListenerMonitorRequestContent.class),
+				callbackCaptor2.capture());
+
 		// verify that loadFences is called
 		verify(geofenceManager, times(1)).loadPersistedData();
-
-		// verify that the internal receivers are registered
-		verify(localBroadcastManager, times(0)).registerReceiver(any(BroadcastReceiver.class), any(IntentFilter.class));
 	}
 
 	// ========================================================================================
@@ -205,17 +212,31 @@ public class PlacesMonitorInternalTests {
 	}
 
 	// ========================================================================================
-	// onUnregistered
+	// onUnexpectedError
 	// ========================================================================================
 	@Test
-	public void test_onUnregistered() {
+	public void test_onUnexpectedError() {
 		// setup
 		initWithContext(context);
 
 		// test
-		monitorInternal.onUnregistered();
+		monitorInternal.onUnexpectedError(extensionUnexpectedError);
 		verify(extensionApi, times(1)).clearSharedEventStates(null);
 	}
+
+    // ========================================================================================
+    // onUnregistered
+    // ========================================================================================
+
+    @Test
+    public void test_onUnregistered() {
+        // setup
+        initWithContext(context);
+
+        // test
+        monitorInternal.onUnregistered();
+        verify(extensionApi, times(1)).clearSharedEventStates(null);
+    }
 
 	// ========================================================================================
 	// queueEvent
@@ -521,114 +542,170 @@ public class PlacesMonitorInternalTests {
 	}
 
 	@Test
-	public void test_processEvents_when_configurationRetrievalError() {
+    public void test_processEvents_when_configurationRetrievalError() {
+        // setup
+        initWithContext(context);
+        when(extensionApi.getSharedEventState(anyString(), any(Event.class),
+                any(ExtensionErrorCallback.class))).thenReturn(null);
+
+        // setup argument captors
+        final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
+
+        // test
+        monitorInternal.queueEvent(startMonitoringEvent);
+        monitorInternal.processEvents();
+
+        // verify getSharedEventState callback
+        verify(extensionApi, times(1)).getSharedEventState(anyString(), any(Event.class), callbackCaptor.capture());
+        ExtensionErrorCallback extensionErrorCallback = callbackCaptor.getValue();
+        assertNotNull("the extension error callback should not be null", extensionErrorCallback);
+
+        // invoking callback with error, should not crash
+        callbackCaptor.getValue().error(ExtensionError.UNEXPECTED_ERROR);
+    }
+
+
+    @Test
+    public void test_processEvents_when_OSLocationEvent() {
+        // setup
+        initWithContext(context);
+        Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
+
+        // test
+        monitorInternal.queueEvent(OSLocationEvent);
+        monitorInternal.processEvents();
+
+        // verify locationManager is called with the correct data
+        verify(locationManager, times(1)).onLocationReceived(locationUpdateEventData());
+    }
+
+    @Test
+    public void test_processEvents_when_OSGeofenceEvent() {
+        // setup
+        initWithContext(context);
+        Whitebox.setInternalState(monitorInternal, "geofenceManager", geofenceManager);
+
+        // test
+        monitorInternal.queueEvent(OSGeofenceEvent);
+        monitorInternal.processEvents();
+
+        // verify geofenceManager is called with the correct data
+        verify(geofenceManager, times(1)).onGeofenceTriggerReceived(geofenceTransitionEventData());
+    }
+
+	@Test
+	public void test_processEvents_when_OSEventUnknownType() {
 		// setup
 		initWithContext(context);
-
-		// setup
-		initWithContext(context);
-		when(extensionApi.getSharedEventState(anyString(), any(Event.class),
-											  any(ExtensionErrorCallback.class))).thenReturn(null);
-
-		// setup argument captors
-		final ArgumentCaptor<ExtensionErrorCallback> callbackCaptor = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
+		Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
+		Whitebox.setInternalState(monitorInternal, "geofenceManager", geofenceManager);
 
 		// test
-		monitorInternal.queueEvent(startMonitoringEvent);
+		monitorInternal.queueEvent(makeOSEvent("UnknownType"));
 		monitorInternal.processEvents();
 
-		// verify getSharedEventState callback
-		verify(extensionApi, times(1)).getSharedEventState(anyString(), any(Event.class), callbackCaptor.capture());
-		ExtensionErrorCallback extensionErrorCallback = callbackCaptor.getValue();
-		assertNotNull("the extension error callback should not be null", extensionErrorCallback);
-
-		// invoking callback with error, should not crash
-		callbackCaptor.getValue().error(ExtensionError.UNEXPECTED_ERROR);
+		// verify no internal methods are called
+		verify(geofenceManager, times(0)).onGeofenceTriggerReceived(geofenceTransitionEventData());
+		verify(locationManager, times(0)).onLocationReceived(locationUpdateEventData());
+		verify(locationManager, times(0)).beginLocationTracking();
+		verify(locationManager, times(0)).stopMonitoring();
+		verify(geofenceManager, times(0)).stopMonitoringFences(true);
 	}
 
 
 	@Test
-	public void test_processEvents_when_nearByPlacesResponse_withEmptyEventData() {
+	public void test_processEvents_when_OSEventWithEmptyEventType() {
 		// setup
 		initWithContext(context);
-
-		// setup configuration
-		Map<String, Object> configData = new HashMap<>();
-		when(extensionApi.getSharedEventState(anyString(), any(Event.class),
-											  any(ExtensionErrorCallback.class))).thenReturn(configData);
+		Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
+		Whitebox.setInternalState(monitorInternal, "geofenceManager", geofenceManager);
 
 		// test
-		monitorInternal.queueEvent(nearByPlacesEvent(new EventData()));
+		monitorInternal.queueEvent(makeOSEvent(""));
 		monitorInternal.processEvents();
 
-		// verify
-		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
-	}
-
-	@Test
-	public void test_processEvents_when_nearByPlacesResponse_withNullEventData() {
-		// setup
-		initWithContext(context);
-
-		// setup configuration
-		Map<String, Object> configData = new HashMap<>();
-		when(extensionApi.getSharedEventState(anyString(), any(Event.class),
-											  any(ExtensionErrorCallback.class))).thenReturn(configData);
-
-		// test
-		monitorInternal.queueEvent(nearByPlacesEvent(null));
-		monitorInternal.processEvents();
-
-		// verify
-		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
+		// verify no internal methods are called
+		verify(geofenceManager, times(0)).onGeofenceTriggerReceived(geofenceTransitionEventData());
+		verify(locationManager, times(0)).onLocationReceived(locationUpdateEventData());
+		verify(locationManager, times(0)).beginLocationTracking();
+		verify(locationManager, times(0)).stopMonitoring();
+		verify(geofenceManager, times(0)).stopMonitoringFences(true);
 	}
 
 
-	@Test
-	public void test_processEvents_when_nearByPlacesResponse_withNullPOIS() {
-		// setup
-		initWithContext(context);
+	// ========================================================================================
+	// process OS location permission change events
+	// ========================================================================================
 
-		// setup configuration
-		Map<String, Object> configData = new HashMap<>();
-		when(extensionApi.getSharedEventState(anyString(), any(Event.class),
-											  any(ExtensionErrorCallback.class))).thenReturn(configData);
+    @Test
+    public void test_processEvents_when_LocationPermissionEvent_GrantedStatus() {
+        // setup
+        initWithContext(context);
+		Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
+		Whitebox.setInternalState(monitorInternal, "geofenceManager", geofenceManager);
 
-		EventData eventData = new EventData();
-		eventData.putTypedList(PlacesMonitorTestConstants.EventDataKeys.NEAR_BY_PLACES_LIST, null,
-							   new PlacesPOIVariantSerializer());
+        // test
+        monitorInternal.queueEvent(makePermissionChangeEvent(PlacesMonitorTestConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_GRANTED));
+        monitorInternal.processEvents();
 
-		// test
-		monitorInternal.queueEvent(nearByPlacesEvent(eventData));
-		monitorInternal.processEvents();
-
-		// verify
-		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
-	}
+        // verify if location tracking is started
+		verify(locationManager, times(1)).beginLocationTracking();
+		verify(locationManager, times(0)).stopMonitoring();
+		verify(geofenceManager, times(0)).stopMonitoringFences(true);
+    }
 
 
 	@Test
-	public void test_moniterInternal_when_locationBroadcasted() {
+	public void test_processEvents_when_LocationPermissionEvent_DeniedStatus() {
 		// setup
 		initWithContext(context);
-
-		// setup configuration
-		Map<String, Object> configData = new HashMap<>();
-		when(extensionApi.getSharedEventState(anyString(), any(Event.class),
-											  any(ExtensionErrorCallback.class))).thenReturn(configData);
-
-		EventData eventData = new EventData();
-		eventData.putTypedList(PlacesMonitorTestConstants.EventDataKeys.NEAR_BY_PLACES_LIST, null,
-							   new PlacesPOIVariantSerializer());
+		Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
+		Whitebox.setInternalState(monitorInternal, "geofenceManager", geofenceManager);
 
 		// test
-		monitorInternal.queueEvent(nearByPlacesEvent(eventData));
+		monitorInternal.queueEvent(makePermissionChangeEvent(PlacesMonitorTestConstants.EventDataValue.OS_LOCATION_PERMISSION_STATUS_DENIED));
 		monitorInternal.processEvents();
 
-		// verify
-		verify(geofenceManager, times(0)).startMonitoringFences(ArgumentMatchers.<PlacesPOI>anyList());
+		// verify if the location tracking and geofence monitoring is stopped
+		verify(locationManager, times(0)).beginLocationTracking();
+		verify(locationManager, times(1)).stopMonitoring();
+		verify(geofenceManager, times(1)).stopMonitoringFences(true);
 	}
 
+
+	@Test
+	public void test_processEvents_when_LocationPermissionEvent_UnknownStatus() {
+		// setup
+		initWithContext(context);
+		Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
+		Whitebox.setInternalState(monitorInternal, "geofenceManager", geofenceManager);
+
+		// test
+		monitorInternal.queueEvent(makePermissionChangeEvent("Unknown event"));
+		monitorInternal.processEvents();
+
+		// verify no action is taken
+		verify(locationManager, times(0)).beginLocationTracking();
+		verify(locationManager, times(0)).stopMonitoring();
+		verify(geofenceManager, times(0)).stopMonitoringFences(true);
+	}
+
+	@Test
+	public void test_processEvents_when_LocationPermissionEvent_EmptyStatus() {
+		// setup
+		initWithContext(context);
+		Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
+		Whitebox.setInternalState(monitorInternal, "geofenceManager", geofenceManager);
+
+		// test
+		monitorInternal.queueEvent(makePermissionChangeEvent(""));
+		monitorInternal.processEvents();
+
+		// verify no action is taken
+		verify(locationManager, times(0)).beginLocationTracking();
+		verify(locationManager, times(0)).stopMonitoring();
+		verify(geofenceManager, times(0)).stopMonitoringFences(true);
+	}
 
 
 	// ========================================================================================
@@ -647,35 +724,6 @@ public class PlacesMonitorInternalTests {
 		assertEquals("Gets the same executor instance on the next get", executorService, monitorInternal.getExecutor());
 	}
 
-	// ========================================================================================
-	// internal receivers
-	// ========================================================================================
-	@Test
-	public void test_internalLocationReceiver() {
-		// setup
-		initWithContext(context);
-		Whitebox.setInternalState(monitorInternal, "locationManager", locationManager);
-		BroadcastReceiver internalLocationReceiver = Whitebox.getInternalState(monitorInternal, "internalLocationReceiver");
-
-		// test
-		internalLocationReceiver.onReceive(context, intent);
-
-		// verify
-		verify(locationManager, times(1)).onLocationReceived(intent);
-	}
-
-	@Test
-	public void test_internalGeofenceReceiver() {
-		// setup
-		initWithContext(context);
-		BroadcastReceiver internalGeofenceReceiver = Whitebox.getInternalState(monitorInternal, "internalGeofenceReceiver");
-
-		// test
-		internalGeofenceReceiver.onReceive(context, intent);
-
-		// verify
-		verify(geofenceManager, times(1)).onGeofenceReceived(intent);
-	}
 
 	// ========================================================================================
 	// getPOIsForLocation
@@ -808,16 +856,15 @@ public class PlacesMonitorInternalTests {
 		Places.clear();
 		verify(locationManager, times(0)).stopMonitoring();
 		verify(geofenceManager, times(0)).stopMonitoringFences(anyBoolean());
-		
 	}
 
+	// ========================================================================================
+	// Private helper methods
+	// ========================================================================================
 
-
-
-	private Event nearByPlacesEvent(final EventData eventData) {
-		return new Event.Builder("Near by Event",
-								 PlacesMonitorTestConstants.EventType.PLACES,
-								 PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT).setData(eventData).build();
+	private void initWithContext(Context context) {
+		Mockito.when(App.getAppContext()).thenReturn(context);
+		monitorInternal = new PlacesMonitorInternal(extensionApi);
 	}
 
 	private List<PlacesPOI> samplePOIList() {
@@ -831,10 +878,54 @@ public class PlacesMonitorInternalTests {
 		return pois;
 	}
 
-	private void initWithContext(Context context) {
-		Mockito.when(App.getAppContext()).thenReturn(context);
-		monitorInternal = new PlacesMonitorInternal(extensionApi);
+	private EventData locationUpdateEventData() {
+	    return new EventData(new HashMap<String,Variant>()
+        {{put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, Variant.fromString(PlacesMonitorTestConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_UPDATE));
+            put(PlacesMonitorConstants.EventDataKey.LATITUDE, Variant.fromDouble(22.22));
+            put(PlacesMonitorConstants.EventDataKey.LONGITUDE, Variant.fromDouble(33.33));}});
+    }
+
+    private EventData geofenceTransitionEventData() {
+     return new EventData(new HashMap<String,Variant>()
+     {{ put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, Variant.fromString(PlacesMonitorTestConstants.EventDataValue.OS_EVENT_TYPE_GEOFENCE_TRIGGER));
+         put(PlacesMonitorConstants.EventDataKey.GEOFENCE_IDS, Variant.fromStringList(getGeofenceIds()));
+         put(PlacesMonitorConstants.EventDataKey.GEOFENCE_TRANSITION_TYPE, Variant.fromInteger(Geofence.GEOFENCE_TRANSITION_ENTER));}});
+    }
+
+	private List<String> getGeofenceIds() {
+	    List<String> geofenceIds = new ArrayList<>();
+	    geofenceIds.add("id1");
+        geofenceIds.add("id2");
+        return geofenceIds;
+    }
+
+
+	private Event makePermissionChangeEvent(final String permissionStatus) {
+		EventData data = new EventData(new HashMap<String, Variant>() {{
+			put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, Variant.fromString(PlacesMonitorConstants.EventDataValue.OS_EVENT_TYPE_LOCATION_PERMISSION_CHANGE));
+			put(PlacesMonitorConstants.EventDataKey.LOCATION_PERMISSION_STATUS, Variant.fromString(permissionStatus));
+		}});
+
+		Event event = new Event.Builder(PlacesMonitorTestConstants.EVENTNAME_OS_PERMISSION_CHANGE,
+				PlacesMonitorTestConstants.EventType.OS,
+				PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT).setData(data).build();
+		return event;
 	}
+
+	private Event makeOSEvent(final String eventType) {
+		EventData data = new EventData(new HashMap<String, Variant>() {{
+			put(PlacesMonitorConstants.EventDataKey.OS_EVENT_TYPE, Variant.fromString(eventType));
+		}});
+
+		Event event = new Event.Builder("OS Event",
+				PlacesMonitorTestConstants.EventType.OS,
+				PlacesMonitorTestConstants.EventSource.RESPONSE_CONTENT).setData(data).build();
+		return event;
+	}
+
+
+
+
 
 
 }

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorListenerOSResponseContentTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorListenerOSResponseContentTests.java
@@ -1,0 +1,126 @@
+/*
+ Copyright 2019 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+*/
+
+//
+// PlacesMonitorListenerOSResponseContentTests.java
+//
+
+
+package com.adobe.marketing.mobile;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PlacesMonitorInternal.class, ExtensionApi.class})
+public class PlacesMonitorListenerOSResponseContentTests {
+
+    @Mock
+    PlacesMonitorInternal mockPlacesMonitorInternal;
+
+    @Mock
+    ExtensionApi extensionApi;
+
+    private int EXECUTOR_TIMEOUT = 5;  // 5 milliseconds
+    private PlacesMonitorListenerOSResponseContent listener;
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Before
+    public void beforeEach() {
+        listener = new PlacesMonitorListenerOSResponseContent(extensionApi, PlacesMonitorTestConstants.EventType.MONITOR,
+                PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT);
+        when(mockPlacesMonitorInternal.getExecutor()).thenReturn(executor);
+        when(extensionApi.getExtension()).thenReturn(mockPlacesMonitorInternal);
+    }
+
+    @Test
+    public void testHear_WithNullEventData() {
+        // setup
+        Event event = new Event.Builder("testEvent", PlacesMonitorTestConstants.EventType.MONITOR,
+                PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT).setData(null).build();
+
+        // test
+        listener.hear(event);
+        waitForExecutor();
+
+        // verify
+        verify(mockPlacesMonitorInternal, times(0)).processEvents();
+    }
+
+    @Test
+    public void testHear_WithNullParentExtension() {
+        // setup
+        EventData eventData = new EventData();
+        eventData.putString("dummyKey", "dummyValue");
+        Event event = new Event.Builder("testEvent", PlacesMonitorTestConstants.EventType.MONITOR,
+                PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT).setData(eventData).build();
+        when(extensionApi.getExtension()).thenReturn(null);
+
+        // test
+        listener.hear(event);
+        waitForExecutor();
+
+        // verify
+        verify(mockPlacesMonitorInternal, times(0)).processEvents();
+
+
+       // Geofence geofence = new Geofence.Builder().setRequestId("id").setTransitionTypes(1).setExpirationDuration(23).setCircularRegion().build();
+
+    }
+
+
+    @Test
+    public void testHear_ValidEvent_Then_QueuesAndProcessesEvent() {
+        // setup
+        EventData eventData = new EventData();
+        eventData.putString("dummyKey", "dummyValue");
+        Event event = new Event.Builder("testEvent", PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT,
+                PlacesMonitorTestConstants.EventType.MONITOR).setData(eventData).build();
+
+        // test
+        listener.hear(event);
+        waitForExecutor();
+
+        // verify
+        verify(mockPlacesMonitorInternal, times(1)).queueEvent(event);
+        verify(mockPlacesMonitorInternal, times(1)).processEvents();
+    }
+
+    void waitForExecutor() {
+        Future<?> future = executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                // Fake task to check the execution termination
+            }
+        });
+
+        try {
+            future.get(EXECUTOR_TIMEOUT, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            fail(String.format("Executor took longer than %s (sec)", EXECUTOR_TIMEOUT));
+        }
+    }
+}

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
@@ -22,13 +22,16 @@ final class PlacesMonitorTestConstants {
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
 	static final String EXTENSION_VERSION = "2.1.0";
-	static final String CONTINUOUS_MONITORING = "continuousmonitoring";
 
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";
 	static final String EVENTNAME_STOP = "stop monitoring";
 	static final String EVENTNAME_UPDATE = "update location now";
 	static final String EVENTNAME_SET_LOCATION_PERMISSION = "set location permission";
+	static final String EVENTNAME_OS_PERMISSION_CHANGE = "OS Permission change";
+	static final String EVENTNAME_OS_GEOFENCE_TRIGGER = "OS Geofence Trigger";
+	static final String EVENTNAME_OS_LOCATION_UPDATE = "OS Location update";
+
 	static final int NEARBY_GEOFENCES_COUNT = 20;
 
 	static final String INTERNAL_INTENT_ACTION_LOCATION = "intentactionlocation";
@@ -46,41 +49,50 @@ final class PlacesMonitorTestConstants {
 	}
 
 	static final class EventSource {
-		static final String RESPONSE_CONTENT 	= "com.adobe.eventsource.responsecontent";
+		static final String RESPONSE_CONTENT = "com.adobe.eventsource.responsecontent";
 		static final String REQUEST_CONTENT = "com.adobe.eventsource.requestcontent";
 		static final String SHARED_STATE = "com.adobe.eventsource.sharedstate";
+
 
 		private EventSource() {
 		}
 	}
 
-	static final class EventDataKeys {
+	static final class EventDataKey {
+		static final String CLEAR = "clearclientdata";
+		static final String LOCATION_PERMISSION = "locationpermission";
 
-		static final String EVENT_DATA_CLEAR	= "clearclientdata";
-		static final String NEAR_BY_PLACES_LIST = "nearbyplaceslist";
-		static final String EVENT_DATA_LOCATION_PERMISSION = "locationpermission";
-		static final String REQUEST_TYPE = "requesttype";
-		static final String REQUEST_TYPE_GET_NEARBY_PLACES = "requestgetnearbyplaces";
-		static final String REQUEST_TYPE_PROCESS_REGION_EVENT = "requestprocessregionevent";
-
-		static final String PLACES_COUNT = "count";
+		static final String OS_EVENT_TYPE = "oseventtype";
 		static final String LATITUDE = "latitude";
 		static final String LONGITUDE = "longitude";
+		static final String GEOFENCE_IDS = "geofenceIds";
+		static final String GEOFENCE_TRANSITION_TYPE = "transitiontype";
+		static final String LOCATION_PERMISSION_STATUS = "locationpermissionstatus";
 
 		static final String GEOFENCE_TYPE_NONE  = "none";
 		static final String GEOFENCE_TYPE_ENTRY = "entry";
 		static final String GEOFENCE_TYPE_EXIT  = "exit";
 
-		static final String REGION_ID = "regionid";
-		static final String REGION_EVENT_TYPE = "regioneventtype";
+		private EventDataKey() {
+		}
+	}
 
-		private EventDataKeys() {
+
+
+	static final class EventDataValue {
+		static final String OS_EVENT_TYPE_LOCATION_UPDATE = "locationupdate";
+		static final String OS_EVENT_TYPE_GEOFENCE_TRIGGER = "geofencetrigger";
+		static final String OS_EVENT_TYPE_LOCATION_PERMISSION_CHANGE = "locationpermissionchange";
+		static final String OS_LOCATION_PERMISSION_STATUS_GRANTED = "granted";
+		static final String OS_LOCATION_PERMISSION_STATUS_DENIED = "denied";
+		private EventDataValue() {
 		}
 	}
 
 
 	static final class EventType {
 		static final String HUB = "com.adobe.eventtype.hub";
+		static final String OS = "com.adobe.eventtype.os";
 		static final String MONITOR = "com.adobe.eventtype.placesmonitor";
 		static final String PLACES = "com.adobe.eventtype.places";
 
@@ -97,7 +109,7 @@ final class PlacesMonitorTestConstants {
 		}
 	}
 
-	static final class SharedPreference {
+	static final class  SharedPreference {
 		static final String MASTER_KEY = "com.adobe.placesMonitor";
 		static final String USERWITHIN_GEOFENCES_KEY = "adb_userWithinGeofences";
 		static final String HAS_MONITORING_STARTED_KEY = "adb_hasMonitoringStarted";

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTests.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTests.java
@@ -28,7 +28,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
@@ -135,7 +134,7 @@ public class PlacesMonitorTests {
 				event.getSource());
 		// verify eventData
 		Map<String,Object> data =event.getEventData();
-		assertEquals(true, data.get(PlacesMonitorTestConstants.EventDataKeys.EVENT_DATA_CLEAR));
+		assertEquals(true, data.get(PlacesMonitorTestConstants.EventDataKey.CLEAR));
 	}
 
 
@@ -164,7 +163,7 @@ public class PlacesMonitorTests {
 				event.getSource());
 		// verify eventData
 		Map<String,Object> data =event.getEventData();
-		assertEquals(false, data.get(PlacesMonitorTestConstants.EventDataKeys.EVENT_DATA_CLEAR));
+		assertEquals(false, data.get(PlacesMonitorTestConstants.EventDataKey.CLEAR));
 	}
 
 
@@ -226,7 +225,7 @@ public class PlacesMonitorTests {
 		assertEquals("the event source should be correct", PlacesMonitorTestConstants.EventSource.REQUEST_CONTENT,
 				event.getSource());
 		assertEquals("the event data size should be correct",1, event.getEventData().size());
-		assertEquals("the event data should be correct",PlacesMonitorLocationPermission.WHILE_USING_APP.getValue(), event.getEventData().get(PlacesMonitorTestConstants.EventDataKeys.EVENT_DATA_LOCATION_PERMISSION));
+		assertEquals("the event data should be correct",PlacesMonitorLocationPermission.WHILE_USING_APP.getValue(), event.getEventData().get(PlacesMonitorTestConstants.EventDataKey.LOCATION_PERMISSION));
 	}
 
 	// ========================================================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


The existing implementation listens to OS Location and Geofence transition events and sends a local broadcast intent for Places Monitor to process the OS data.

 

The above implementation may lead to a race condition where the OS event which is Locally Broadcasted may not be listened by the Places Monitor extension, If Places Monitor extension is not registered on time.  (Reason Places Registration happens on EventHub thread  and the broadcast receiver operates on main thread).

The fix would be for PlacesMonitor to listen to the OS Broadcasted event after the registration of the extension is complete.

 

The solution is to dispatch an OS event to eventHub once we the broadcastListeners are triggered. This allows the PlacesMonitor Extension to be registered in time before we process the OS event dispatched by the eventHub.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes


 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
