### PR TITLE
[AMSDK-11092] - Catch ActivityNotFoundException during permission req…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
-version: 2.1
-orbs:
-  android: circleci/android@1.0
+version: 2.0
 
 jobs:
   build:
@@ -13,7 +11,7 @@ jobs:
       - checkout
       - run:
           name: Javadoc
-          command: code/gradlew -q -p code/places-monitor-android javadocPublic       
+          command: code/gradlew -q -p code/places-monitor-android javadocPublic
       - run:
           name: Build
           command: code/gradlew -p code/places-monitor-android assemblePhoneCoreBundleDebug
@@ -43,7 +41,7 @@ workflows:
   version: 2
   build-test-approve-and-publish:
     jobs:
-      - build  
+      - build
       - test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2.0
+version: 2.1
+orbs:
+  android: circleci/android@1.0
+
 jobs:
   build:
     working_directory: ~/code

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -14,7 +14,7 @@ artifactoryPassword=xxx
 moduleProjectName=places-monitor-android
 moduleName=places-monitor
 moduleAARName=places-monitor-android-phone-coreBundle-release.aar
-moduleVersion=2.2.1
+moduleVersion=2.2.2
 
 #bourbon-platform-android-module.gradle
 mavenRepoName=AdobeMobilePlacesMonitorSdk

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -17,6 +17,7 @@ package com.adobe.marketing.mobile;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -218,8 +219,13 @@ public class PlacesActivity extends Activity {
 		if (shouldProvideRationale) {
 			onShowRationale(locationPermission);
 		} else {
-			ActivityCompat.requestPermissions(this, getPermissionArray(locationPermission),
-											  PlacesMonitorConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE);
+			try {
+				ActivityCompat.requestPermissions(this, getPermissionArray(locationPermission),
+						PlacesMonitorConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE);
+			} catch (ActivityNotFoundException exception) {
+				Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to find System Activity to hand request permission activity dialog. Hence Places Monitor cannot request for location permission.");
+			}
+
 		}
 	}
 
@@ -397,7 +403,4 @@ public class PlacesActivity extends Activity {
 		editor.putBoolean(PlacesMonitorConstants.SharedPreference.HAS_LOCATION_DIALOG_PROMPTED, isPrompted);
 		editor.apply();
 	}
-
-
 }
-

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesActivity.java
@@ -223,7 +223,7 @@ public class PlacesActivity extends Activity {
 				ActivityCompat.requestPermissions(this, getPermissionArray(locationPermission),
 						PlacesMonitorConstants.MONITOR_LOCATION_PERMISSION_REQUEST_CODE);
 			} catch (ActivityNotFoundException exception) {
-				Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to find System Activity to hand request permission activity dialog. Hence Places Monitor cannot request for location permission.");
+				Log.warning(PlacesMonitorConstants.LOG_TAG, "Unable to find System Activity to handle request permission activity dialog. Hence Places Monitor cannot request for location permission.");
 			}
 
 		}

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
@@ -22,7 +22,7 @@ final class PlacesMonitorConstants {
 	static final String LOG_TAG = PlacesMonitor.class.getSimpleName();
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
-	static final String EXTENSION_VERSION = "2.2.1";
+	static final String EXTENSION_VERSION = "2.2.2";
 
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
@@ -21,7 +21,7 @@ final class PlacesMonitorTestConstants {
 
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
-	static final String EXTENSION_VERSION = "2.2.1";
+	static final String EXTENSION_VERSION = "2.2.2";
 
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";


### PR DESCRIPTION
Elegant handling of the exception happening because unable to create a systemActivity to pop up the location permission dialog.

With this change, the SDK doesn't crash and handles the exception by print a log message.

Crash log.

![Screen Shot 2021-03-23 at 1 19 35 PM](https://user-images.githubusercontent.com/8909148/112212817-ac9c7c00-8bda-11eb-9c70-ec5f2e398523.png)
