### PR TITLE
Release 2.2.3 [MOB-16270] - Fix android:export manifest error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Android PlaceMonitor change log
 
+#### 2.2.3 (28 Mar, 2022)
+- Fixed an error for app's targeting Android 12 that requires `android:exported` to be added for each broadcast receivers in Manifest file.
+
 #### 2.2.2 (10 May, 2021)
 - Fixed a crash that was caused when application did not find the required activity for requesting location permission.
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.configureondemand=false
 moduleProjectName=places-monitor-android
 moduleName=places-monitor
 moduleAARName=places-monitor-android-phone-release.aar
-moduleVersion=2.2.2
+moduleVersion=2.2.3
 
 #bourbon-platform-android-module.gradle
 mavenRepoName=AdobeMobilePlacesMonitorSdk

--- a/code/places-monitor-android/src/main/AndroidManifest.xml
+++ b/code/places-monitor-android/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name="com.adobe.marketing.mobile.PlacesMonitorOnBootReceiver">
+        <receiver android:name="com.adobe.marketing.mobile.PlacesMonitorOnBootReceiver"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>

--- a/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
+++ b/code/places-monitor-android/src/phone/java/com/adobe/marketing/mobile/PlacesMonitorConstants.java
@@ -22,7 +22,7 @@ final class PlacesMonitorConstants {
 	static final String LOG_TAG = PlacesMonitor.class.getSimpleName();
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
-	static final String EXTENSION_VERSION = "2.2.2";
+	static final String EXTENSION_VERSION = "2.2.3";
 
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";

--- a/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
+++ b/code/places-monitor-android/src/test/java/com/adobe/marketing/mobile/PlacesMonitorTestConstants.java
@@ -21,7 +21,7 @@ final class PlacesMonitorTestConstants {
 
 	static final String EXTENSION_NAME = "com.adobe.placesMonitor";
 
-	static final String EXTENSION_VERSION = "2.2.2";
+	static final String EXTENSION_VERSION = "2.2.3";
 
 	// event names for places monitor request content
 	static final String EVENTNAME_START = "start monitoring";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**Release v2.2.3**
Changes made to explicitly set element `android:exported https://developer.android.com/guide/topics/manifest/activity-element#exported` to BOOT_COMPLETED broadcast receiver.


For app's targeting Android 12 and if you are using Android Studio 2020.3.1 Canary 11 or later, you need to set android:exported on each activity, service, and receiver on your AndroidManifest.xml file. Else the build fails with error 

Error: Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.

